### PR TITLE
Fix for refactor

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -930,74 +930,122 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             return
         if path[0] == "warehouses":
             warehouse_id = int(path[1])
-            data_provider.fetch_warehouse_pool().remove_warehouse(warehouse_id)
+            check = data_provider.fetch_warehouse_pool().remove_warehouse(warehouse_id)
+            if (check is False):
+                self.send_response(404, "ID not found or other Data is dependent on this data")
+                self.end_headers()
+                return
             data_provider.fetch_warehouse_pool().save()
             self.send_response(200)
             self.end_headers()
         elif path[0] == "locations":
             location_id = int(path[1])
-            data_provider.fetch_location_pool().remove_location(location_id)
+            check = data_provider.fetch_location_pool().remove_location(location_id)
+            if (check is False):
+                self.send_response(404, "ID not found or other Data is dependent on this data")
+                self.end_headers()
+                return
             data_provider.fetch_location_pool().save()
             self.send_response(200)
             self.end_headers()
         elif path[0] == "transfers":
             transfer_id = int(path[1])
-            data_provider.fetch_transfer_pool().remove_transfer(transfer_id)
+            check = data_provider.fetch_transfer_pool().remove_transfer(transfer_id)
+            if (check is False):
+                self.send_response(404, "ID not found or other Data is dependent on this data")
+                self.end_headers()
+                return
             data_provider.fetch_transfer_pool().save()
             self.send_response(200)
             self.end_headers()
         elif path[0] == "items":
             item_id = path[1]
-            data_provider.fetch_item_pool().remove_item(item_id)
+            check = data_provider.fetch_item_pool().remove_item(item_id)
+            if (check is False):
+                self.send_response(404, "ID not found or other Data is dependent on this data")
+                self.end_headers()
+                return
             data_provider.fetch_item_pool().save()
             self.send_response(200)
             self.end_headers()
         elif path[0] == "item_lines":
             item_line_id = int(path[1])
-            data_provider.fetch_item_line_pool().remove_item_line(item_line_id)
+            check = data_provider.fetch_item_line_pool().remove_item_line(item_line_id)
+            if (check is False):
+                self.send_response(404, "ID not found or other Data is dependent on this data")
+                self.end_headers()
+                return
             data_provider.fetch_item_line_pool().save()
             self.send_response(200)
             self.end_headers()
         elif path[0] == "item_groups":
             item_group_id = int(path[1])
-            data_provider.fetch_item_group_pool() \
+            check = data_provider.fetch_item_group_pool() \
                 .remove_item_group(item_group_id)
+            if (check is False):
+                self.send_response(404, "ID not found or other Data is dependent on this data")
+                self.end_headers()
+                return
             data_provider.fetch_item_group_pool().save()
             self.send_response(200)
             self.end_headers()
         elif path[0] == "item_types":
             item_type_id = int(path[1])
-            data_provider.fetch_item_type_pool().remove_item_type(item_type_id)
+            check = data_provider.fetch_item_type_pool().remove_item_type(item_type_id)
+            if (check is False):
+                self.send_response(404, "ID not found or other Data is dependent on this data")
+                self.end_headers()
+                return
             data_provider.fetch_item_type_pool().save()
             self.send_response(200)
             self.end_headers()
         elif path[0] == "inventories":
             inventory_id = int(path[1])
-            data_provider.fetch_inventory_pool().remove_inventory(inventory_id)
+            check = data_provider.fetch_inventory_pool().remove_inventory(inventory_id)
+            if (check is False):
+                self.send_response(404, "ID not found or other Data is dependent on this data")
+                self.end_headers()
+                return
             data_provider.fetch_inventory_pool().save()
             self.send_response(200)
             self.end_headers()
         elif path[0] == "suppliers":
             supplier_id = int(path[1])
-            data_provider.fetch_supplier_pool().remove_supplier(supplier_id)
+            check = data_provider.fetch_supplier_pool().remove_supplier(supplier_id)
+            if (check is False):
+                self.send_response(404, "ID not found or other Data is dependent on this data")
+                self.end_headers()
+                return
             data_provider.fetch_supplier_pool().save()
             self.send_response(200)
             self.end_headers()
         elif path[0] == "orders":
             order_id = int(path[1])
-            data_provider.fetch_order_pool().remove_order(order_id)
+            check = data_provider.fetch_order_pool().remove_order(order_id)
+            if (check is False):
+                self.send_response(404, "ID not found or other Data is dependent on this data")
+                self.end_headers()
+                return
             data_provider.fetch_order_pool().save()
             self.send_response(200)
             self.end_headers()
         elif path[0] == "clients":
             client_id = int(path[1])
-            data_provider.fetch_client_pool().remove_client(client_id)
+            check = data_provider.fetch_client_pool().remove_client(client_id)
+            if (check is False):
+                self.send_response(404, "ID not found or other Data is dependent on this data")
+                self.end_headers()
+                return
             data_provider.fetch_client_pool().save()
             self.send_response(200)
             self.end_headers()
         elif path[0] == "shipments":
             shipment_id = int(path[1])
-            data_provider.fetch_shipment_pool().remove_shipment(shipment_id)
+            check = data_provider.fetch_shipment_pool().remove_shipment(shipment_id)
+            if (check is False):
+                self.send_response(404, "ID not found or other Data is dependent on this data")
+                self.end_headers()
+                return
             data_provider.fetch_shipment_pool().save()
             self.send_response(200)
             self.end_headers()

--- a/api/main.py
+++ b/api/main.py
@@ -603,8 +603,12 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             updated_warehouse = json.loads(post_data.decode())
-            data_provider.fetch_warehouse_pool() \
+            check = data_provider.fetch_warehouse_pool() \
                 .update_warehouse(warehouse_id, updated_warehouse)
+            if (check is False):
+                self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                self.end_headers()
+                return
             data_provider.fetch_warehouse_pool().save()
             self.send_response(200)
             self.end_headers()
@@ -613,8 +617,12 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             updated_location = json.loads(post_data.decode())
-            data_provider.fetch_location_pool() \
+            check = data_provider.fetch_location_pool() \
                 .update_location(location_id, updated_location)
+            if (check is False):
+                self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                self.end_headers()
+                return
             data_provider.fetch_location_pool().save()
             self.send_response(200)
             self.end_headers()
@@ -626,8 +634,12 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
                     content_length = int(self.headers["Content-Length"])
                     post_data = self.rfile.read(content_length)
                     updated_transfer = json.loads(post_data.decode())
-                    data_provider.fetch_transfer_pool() \
+                    check = data_provider.fetch_transfer_pool() \
                         .update_transfer(transfer_id, updated_transfer)
+                    if (check is False):
+                        self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                        self.end_headers()
+                        return
                     data_provider.fetch_transfer_pool().save()
                     self.send_response(200)
                     self.end_headers()
@@ -659,8 +671,12 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
                                     data_provider.fetch_inventory_pool() \
                                         .update_inventory(y["id"], y)
                         transfer["transfer_status"] = "Processed"
-                        data_provider.fetch_transfer_pool() \
+                        check = data_provider.fetch_transfer_pool() \
                             .update_transfer(transfer_id, transfer)
+                        if (check is False):
+                            self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                            self.end_headers()
+                            return
                         notification_processor.push(
                             (f"Processed batch transfer with id:"
                              f"{transfer['id']}"))
@@ -679,7 +695,11 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             updated_item = json.loads(post_data.decode())
-            data_provider.fetch_item_pool().update_item(item_id, updated_item)
+            check = data_provider.fetch_item_pool().update_item(item_id, updated_item)
+            if (check is False):
+                self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                self.end_headers()
+                return
             data_provider.fetch_item_pool().save()
             self.send_response(200)
             self.end_headers()
@@ -688,8 +708,12 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             updated_item_line = json.loads(post_data.decode())
-            data_provider.fetch_item_line_pool() \
+            check = data_provider.fetch_item_line_pool() \
                 .update_item_line(item_line_id, updated_item_line)
+            if (check is False):
+                self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                self.end_headers()
+                return
             data_provider.fetch_item_line_pool().save()
             self.send_response(200)
             self.end_headers()
@@ -698,9 +722,13 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             updated_item_group = json.loads(post_data.decode())
-            data_provider.fetch_item_group_pool() \
+            check = data_provider.fetch_item_group_pool() \
                 .update_item_group(item_group_id, updated_item_group)
             data_provider.fetch_item_group_pool().save()
+            if (check is False):
+                self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                self.end_headers()
+                return
             self.send_response(200)
             self.end_headers()
         elif path[0] == "item_types":
@@ -708,8 +736,12 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             updated_item_type = json.loads(post_data.decode())
-            data_provider.fetch_item_type_pool() \
+            check = data_provider.fetch_item_type_pool() \
                 .update_item_type(item_type_id, updated_item_type)
+            if (check is False):
+                self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                self.end_headers()
+                return
             data_provider.fetch_item_type_pool().save()
             self.send_response(200)
             self.end_headers()
@@ -718,8 +750,12 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             updated_inventory = json.loads(post_data.decode())
-            data_provider.fetch_inventory_pool() \
+            check = data_provider.fetch_inventory_pool() \
                 .update_inventory(inventory_id, updated_inventory)
+            if (check is False):
+                self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                self.end_headers()
+                return
             data_provider.fetch_inventory_pool().save()
             self.send_response(200)
             self.end_headers()
@@ -728,8 +764,12 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             updated_supplier = json.loads(post_data.decode())
-            data_provider.fetch_supplier_pool() \
+            check = data_provider.fetch_supplier_pool() \
                 .update_supplier(supplier_id, updated_supplier)
+            if (check is False):
+                self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                self.end_headers()
+                return
             data_provider.fetch_supplier_pool().save()
             self.send_response(200)
             self.end_headers()
@@ -741,8 +781,12 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
                     content_length = int(self.headers["Content-Length"])
                     post_data = self.rfile.read(content_length)
                     updated_order = json.loads(post_data.decode())
-                    data_provider.fetch_order_pool() \
+                    check = data_provider.fetch_order_pool() \
                         .update_order(order_id, updated_order)
+                    if (check is False):
+                        self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                        self.end_headers()
+                        return
                     data_provider.fetch_order_pool().save()
                     self.send_response(200)
                     self.end_headers()
@@ -752,8 +796,12 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
                         content_length = int(self.headers["Content-Length"])
                         post_data = self.rfile.read(content_length)
                         updated_items = json.loads(post_data.decode())
-                        data_provider.fetch_order_pool() \
+                        check = data_provider.fetch_order_pool() \
                             .update_items_in_order(order_id, updated_items)
+                        if (check is False):
+                            self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                            self.end_headers()
+                            return
                         data_provider.fetch_order_pool().save()
                         self.send_response(200)
                         self.end_headers()
@@ -768,8 +816,12 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             updated_client = json.loads(post_data.decode())
-            data_provider.fetch_client_pool() \
+            check = data_provider.fetch_client_pool() \
                 .update_client(client_id, updated_client)
+            if (check is False):
+                self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                self.end_headers()
+                return
             data_provider.fetch_client_pool().save()
             self.send_response(200)
             self.end_headers()
@@ -781,8 +833,12 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
                     content_length = int(self.headers["Content-Length"])
                     post_data = self.rfile.read(content_length)
                     updated_shipment = json.loads(post_data.decode())
-                    data_provider.fetch_shipment_pool() \
+                    check = data_provider.fetch_shipment_pool() \
                         .update_shipment(shipment_id, updated_shipment)
+                    if (check is False):
+                        self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                        self.end_headers()
+                        return
                     data_provider.fetch_shipment_pool().save()
                     self.send_response(200)
                     self.end_headers()
@@ -792,9 +848,13 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
                         content_length = int(self.headers["Content-Length"])
                         post_data = self.rfile.read(content_length)
                         updated_orders = json.loads(post_data.decode())
-                        data_provider.fetch_order_pool() \
+                        check = data_provider.fetch_order_pool() \
                             .update_orders_in_shipment(shipment_id,
                                                        updated_orders)
+                        if (check is False):
+                            self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                            self.end_headers()
+                            return
                         data_provider.fetch_order_pool().save()
                         self.send_response(200)
                         self.end_headers()
@@ -806,6 +866,10 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
                         data_provider.fetch_shipment_pool() \
                             .update_items_in_shipment(shipment_id,
                                                       updated_items)
+                        if (check is False):
+                            self.send_response(404, "ID not found or ID in Body and in Route are not matching")
+                            self.end_headers()
+                            return
                         data_provider.fetch_shipment_pool().save()
                         self.send_response(200)
                         self.end_headers()

--- a/api/main.py
+++ b/api/main.py
@@ -432,7 +432,11 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             new_warehouse = json.loads(post_data.decode())
-            data_provider.fetch_warehouse_pool().add_warehouse(new_warehouse)
+            check = data_provider.fetch_warehouse_pool().add_warehouse(new_warehouse)
+            if (check is False):
+                self.send_response(404, "ID in Body already exists in data")
+                self.end_headers()
+                return
             data_provider.fetch_warehouse_pool().save()
             self.send_response(201)
             self.end_headers()
@@ -440,7 +444,11 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             new_location = json.loads(post_data.decode())
-            data_provider.fetch_location_pool().add_location(new_location)
+            check = data_provider.fetch_location_pool().add_location(new_location)
+            if (check is False):
+                self.send_response(404, "ID in Body already exists in data")
+                self.end_headers()
+                return
             data_provider.fetch_location_pool().save()
             self.send_response(201)
             self.end_headers()
@@ -448,7 +456,11 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             new_transfer = json.loads(post_data.decode())
-            data_provider.fetch_transfer_pool().add_transfer(new_transfer)
+            check = data_provider.fetch_transfer_pool().add_transfer(new_transfer)
+            if (check is False):
+                self.send_response(404, "ID in Body already exists in data")
+                self.end_headers()
+                return
             data_provider.fetch_transfer_pool().save()
             notification_processor.push(
                 f"Scheduled batch transfer {new_transfer['id']}")
@@ -458,15 +470,59 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             new_item = json.loads(post_data.decode())
-            data_provider.fetch_item_pool().add_item(new_item)
+            check = data_provider.fetch_item_pool().add_item(new_item)
+            if (check is False):
+                self.send_response(404, "ID in Body already exists in data")
+                self.end_headers()
+                return
             data_provider.fetch_item_pool().save()
+            self.send_response(201)
+            self.end_headers()
+        elif path[0] == "item_lines":
+            content_length = int(self.headers["Content-Length"])
+            post_data = self.rfile.read(content_length)
+            new_item_line = json.loads(post_data.decode())
+            check = data_provider.fetch_item_line_pool().add_item_line(new_item_line)
+            if (check is False):
+                self.send_response(404, "ID in Body already exists in data")
+                self.end_headers()
+                return
+            data_provider.fetch_item_line_pool().save()
+            self.send_response(201)
+            self.end_headers()
+        elif path[0] == "item_types":
+            content_length = int(self.headers["Content-Length"])
+            post_data = self.rfile.read(content_length)
+            new_item_type = json.loads(post_data.decode())
+            check = data_provider.fetch_item_type_pool().add_item_type(new_item_type)
+            if (check is False):
+                self.send_response(404, "ID in Body already exists in data")
+                self.end_headers()
+                return
+            data_provider.fetch_item_type_pool().save()
+            self.send_response(201)
+            self.end_headers()
+        elif path[0] == "item_groups":
+            content_length = int(self.headers["Content-Length"])
+            post_data = self.rfile.read(content_length)
+            new_item_group = json.loads(post_data.decode())
+            check = data_provider.fetch_item_group_pool().add_item_group(new_item_group)
+            if (check is False):
+                self.send_response(404, "ID in Body already exists in data")
+                self.end_headers()
+                return
+            data_provider.fetch_item_group_pool().save()
             self.send_response(201)
             self.end_headers()
         elif path[0] == "inventories":
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             new_inventory = json.loads(post_data.decode())
-            data_provider.fetch_inventory_pool().add_inventory(new_inventory)
+            check = data_provider.fetch_inventory_pool().add_inventory(new_inventory)
+            if (check is False):
+                self.send_response(404, "ID in Body already exists in data")
+                self.end_headers()
+                return
             data_provider.fetch_inventory_pool().save()
             self.send_response(201)
             self.end_headers()
@@ -474,7 +530,11 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             new_supplier = json.loads(post_data.decode())
-            data_provider.fetch_supplier_pool().add_supplier(new_supplier)
+            check = data_provider.fetch_supplier_pool().add_supplier(new_supplier)
+            if (check is False):
+                self.send_response(404, "ID in Body already exists in data")
+                self.end_headers()
+                return
             data_provider.fetch_supplier_pool().save()
             self.send_response(201)
             self.end_headers()
@@ -482,7 +542,11 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             new_order = json.loads(post_data.decode())
-            data_provider.fetch_order_pool().add_order(new_order)
+            check = data_provider.fetch_order_pool().add_order(new_order)
+            if (check is False):
+                self.send_response(404, "ID in Body already exists in data")
+                self.end_headers()
+                return
             data_provider.fetch_order_pool().save()
             self.send_response(201)
             self.end_headers()
@@ -490,7 +554,11 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             new_client = json.loads(post_data.decode())
-            data_provider.fetch_client_pool().add_client(new_client)
+            check = data_provider.fetch_client_pool().add_client(new_client)
+            if (check is False):
+                self.send_response(404, "ID in Body already exists in data")
+                self.end_headers()
+                return
             data_provider.fetch_client_pool().save()
             self.send_response(201)
             self.end_headers()
@@ -498,7 +566,11 @@ class ApiRequestHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers["Content-Length"])
             post_data = self.rfile.read(content_length)
             new_shipment = json.loads(post_data.decode())
-            data_provider.fetch_shipment_pool().add_shipment(new_shipment)
+            check = data_provider.fetch_shipment_pool().add_shipment(new_shipment)
+            if (check is False):
+                self.send_response(404, "ID in Body already exists in data")
+                self.end_headers()
+                return
             data_provider.fetch_shipment_pool().save()
             self.send_response(201)
             self.end_headers()

--- a/api/models/clients.py
+++ b/api/models/clients.py
@@ -1,6 +1,7 @@
 import json
 
 from models.base import Base
+from providers import data_provider
 
 CLIENTS = []
 
@@ -39,9 +40,16 @@ class Clients(Base):
                 break
 
     def remove_client(self, client_id):
+        client = self.get_client(client_id)
+        if client is None: return False
+        orders = data_provider.fetch_order_pool().get_orders()
+        for x in orders:
+            if x["ship_to"] == client_id or x["bill_to"] == client_id:
+                return False
         for x in self.data:
             if x["id"] == client_id:
                 self.data.remove(x)
+                return True
 
     def load(self, is_debug):
         if is_debug:

--- a/api/models/clients.py
+++ b/api/models/clients.py
@@ -29,6 +29,9 @@ class Clients(Base):
         return True
 
     def update_client(self, client_id, client):
+        if "id" in client:
+            if client_id != client["id"]:
+                return False
         client["updated_at"] = self.get_timestamp()
         for i in range(len(self.data)):
             if self.data[i]["id"] == client_id:

--- a/api/models/clients.py
+++ b/api/models/clients.py
@@ -20,9 +20,13 @@ class Clients(Base):
         return None
 
     def add_client(self, client):
+        for x in self.data:
+            if x["id"] == client["id"]:
+                return False
         client["created_at"] = self.get_timestamp()
         client["updated_at"] = self.get_timestamp()
         self.data.append(client)
+        return True
 
     def update_client(self, client_id, client):
         client["updated_at"] = self.get_timestamp()

--- a/api/models/inventories.py
+++ b/api/models/inventories.py
@@ -1,6 +1,7 @@
 import json
 
 from models.base import Base
+from providers import data_provider
 
 INVENTORIES = []
 
@@ -61,9 +62,14 @@ class Inventories(Base):
                 return True
 
     def remove_inventory(self, inventory_id):
+        inventory = self.get_inventory(inventory_id)
+        if inventory is None: return False
+        item = data_provider.fetch_item_pool().get_item(inventory["item_id"])
+        if item is not None: return False
         for x in self.data:
             if x["id"] == inventory_id:
                 self.data.remove(x)
+                return True
 
     def load(self, is_debug):
         if is_debug:

--- a/api/models/inventories.py
+++ b/api/models/inventories.py
@@ -42,9 +42,13 @@ class Inventories(Base):
         return result
 
     def add_inventory(self, inventory):
+        for x in self.data:
+            if x["id"] == inventory["id"]:
+                return False
         inventory["created_at"] = self.get_timestamp()
         inventory["updated_at"] = self.get_timestamp()
         self.data.append(inventory)
+        return True
 
     def update_inventory(self, inventory_id, inventory):
         inventory["updated_at"] = self.get_timestamp()

--- a/api/models/inventories.py
+++ b/api/models/inventories.py
@@ -51,11 +51,14 @@ class Inventories(Base):
         return True
 
     def update_inventory(self, inventory_id, inventory):
+        if "id" in inventory:
+            if inventory_id != inventory["id"]:
+                return False
         inventory["updated_at"] = self.get_timestamp()
         for i in range(len(self.data)):
             if self.data[i]["id"] == inventory_id:
                 self.data[i] = inventory
-                break
+                return True
 
     def remove_inventory(self, inventory_id):
         for x in self.data:

--- a/api/models/item_groups.py
+++ b/api/models/item_groups.py
@@ -1,6 +1,7 @@
 import json
 
 from models.base import Base
+from providers import data_provider
 
 ITEM_GROUPS = []
 
@@ -39,9 +40,14 @@ class ItemGroups(Base):
                 return True
 
     def remove_item_group(self, item_group_id):
+        item_group = self.get_item_group(item_group_id)
+        if item_group is None: return False
+        items = data_provider.fetch_item_pool().get_items_for_item_group(item_group_id)
+        if len(items) != 0: return False
         for x in self.data:
             if x["id"] == item_group_id:
                 self.data.remove(x)
+                return True
 
     def load(self, is_debug):
         if is_debug:

--- a/api/models/item_groups.py
+++ b/api/models/item_groups.py
@@ -7,7 +7,7 @@ ITEM_GROUPS = []
 
 class ItemGroups(Base):
     def __init__(self, root_path, is_debug=False):
-        self.data_path = root_path + "item_lines.json"
+        self.data_path = root_path + "item_groups.json"
         self.load(is_debug)
 
     def get_item_groups(self):
@@ -20,9 +20,13 @@ class ItemGroups(Base):
         return None
 
     def add_item_group(self, item_group):
+        for x in self.data:
+            if x["id"] == item_group["id"]:
+                return False
         item_group["created_at"] = self.get_timestamp()
         item_group["updated_at"] = self.get_timestamp()
         self.data.append(item_group)
+        return True
 
     def update_item_group(self, item_group_id, item_group):
         item_group["updated_at"] = self.get_timestamp()

--- a/api/models/item_groups.py
+++ b/api/models/item_groups.py
@@ -29,11 +29,14 @@ class ItemGroups(Base):
         return True
 
     def update_item_group(self, item_group_id, item_group):
+        if "id" in item_group:
+            if item_group_id != item_group["id"]:
+                return False
         item_group["updated_at"] = self.get_timestamp()
         for i in range(len(self.data)):
             if self.data[i]["id"] == item_group_id:
                 self.data[i] = item_group
-                break
+                return True
 
     def remove_item_group(self, item_group_id):
         for x in self.data:

--- a/api/models/item_lines.py
+++ b/api/models/item_lines.py
@@ -1,6 +1,7 @@
 import json
 
 from models.base import Base
+from providers import data_provider
 
 ITEM_LINES = []
 
@@ -39,9 +40,14 @@ class ItemLines(Base):
                 return True
 
     def remove_item_line(self, item_line_id):
+        item_line = self.get_item_line(item_line_id)
+        if item_line is None: return False
+        items = data_provider.fetch_item_pool().get_items_for_item_line(item_line_id)
+        if len(items) != 0: return False
         for x in self.data:
             if x["id"] == item_line_id:
                 self.data.remove(x)
+                return True
 
     def load(self, is_debug):
         if is_debug:

--- a/api/models/item_lines.py
+++ b/api/models/item_lines.py
@@ -20,9 +20,13 @@ class ItemLines(Base):
         return None
 
     def add_item_line(self, item_line):
+        for x in self.data:
+            if x["id"] == item_line["id"]:
+                return False
         item_line["created_at"] = self.get_timestamp()
         item_line["updated_at"] = self.get_timestamp()
         self.data.append(item_line)
+        return True
 
     def update_item_line(self, item_line_id, item_line):
         item_line["updated_at"] = self.get_timestamp()

--- a/api/models/item_lines.py
+++ b/api/models/item_lines.py
@@ -29,11 +29,14 @@ class ItemLines(Base):
         return True
 
     def update_item_line(self, item_line_id, item_line):
+        if "id" in item_line:
+            if item_line_id != item_line["id"]:
+                return False
         item_line["updated_at"] = self.get_timestamp()
         for i in range(len(self.data)):
             if self.data[i]["id"] == item_line_id:
                 self.data[i] = item_line
-                break
+                return True
 
     def remove_item_line(self, item_line_id):
         for x in self.data:

--- a/api/models/item_types.py
+++ b/api/models/item_types.py
@@ -1,6 +1,7 @@
 import json
 
 from models.base import Base
+from providers import data_provider
 
 ITEM_TYPES = []
 
@@ -39,9 +40,14 @@ class ItemTypes(Base):
                 return True
 
     def remove_item_type(self, item_type_id):
+        item_type = self.get_item_type(item_type_id)
+        if item_type is None: return False
+        items = data_provider.fetch_item_pool().get_items_for_item_type(item_type_id)
+        if len(items) != 0: return False
         for x in self.data:
             if x["id"] == item_type_id:
                 self.data.remove(x)
+                return True
 
     def load(self, is_debug):
         if is_debug:

--- a/api/models/item_types.py
+++ b/api/models/item_types.py
@@ -29,11 +29,14 @@ class ItemTypes(Base):
         return True
 
     def update_item_type(self, item_type_id, item_type):
+        if "id" in item_type:
+            if item_type_id != item_type["id"]:
+                return False
         item_type["updated_at"] = self.get_timestamp()
         for i in range(len(self.data)):
             if self.data[i]["id"] == item_type_id:
                 self.data[i] = item_type
-                break
+                return True
 
     def remove_item_type(self, item_type_id):
         for x in self.data:

--- a/api/models/item_types.py
+++ b/api/models/item_types.py
@@ -20,9 +20,13 @@ class ItemTypes(Base):
         return None
 
     def add_item_type(self, item_type):
+        for x in self.data:
+            if x["id"] == item_type["id"]:
+                return False
         item_type["created_at"] = self.get_timestamp()
         item_type["updated_at"] = self.get_timestamp()
         self.data.append(item_type)
+        return True
 
     def update_item_type(self, item_type_id, item_type):
         item_type["updated_at"] = self.get_timestamp()

--- a/api/models/items.py
+++ b/api/models/items.py
@@ -48,9 +48,13 @@ class Items(Base):
         return result
 
     def add_item(self, item):
+        for x in self.data:
+            if x["uid"] == item["uid"]:
+                return False
         item["created_at"] = self.get_timestamp()
         item["updated_at"] = self.get_timestamp()
         self.data.append(item)
+        return True
 
     def update_item(self, item_id, item):
         item["updated_at"] = self.get_timestamp()

--- a/api/models/items.py
+++ b/api/models/items.py
@@ -57,11 +57,14 @@ class Items(Base):
         return True
 
     def update_item(self, item_id, item):
+        if "id" in item:
+            if item_id != item["id"]:
+                return False
         item["updated_at"] = self.get_timestamp()
         for i in range(len(self.data)):
             if self.data[i]["uid"] == item_id:
                 self.data[i] = item
-                break
+                return True
 
     def remove_item(self, item_id):
         for x in self.data:

--- a/api/models/items.py
+++ b/api/models/items.py
@@ -1,6 +1,7 @@
 import json
 
 from models.base import Base
+from providers import data_provider
 
 ITEMS = []
 
@@ -67,9 +68,30 @@ class Items(Base):
                 return True
 
     def remove_item(self, item_id):
+        item = self.get_item(item_id)
+        if item is None: return False
+        orders = data_provider.fetch_order_pool().get_orders()
+        for y in orders:
+            for items in y["items"]:
+                for z in items:
+                    if z == x:
+                        return False
+        shipments = data_provider.fetch_shipment_pool().get_shipments()
+        for y in shipments:
+            for items in y["items"]:
+                for z in items:
+                    if z == x:
+                        return False
+        transfers = data_provider.fetch_transfer_pool().get_transfers()
+        for y in transfers:
+            for items in y["items"]:
+                for z in items:
+                    if z == x:
+                        return False
         for x in self.data:
             if x["uid"] == item_id:
                 self.data.remove(x)
+                return True
 
     def load(self, is_debug):
         if is_debug:

--- a/api/models/locations.py
+++ b/api/models/locations.py
@@ -36,11 +36,14 @@ class Locations(Base):
         return True
 
     def update_location(self, location_id, location):
+        if "id" in location:
+            if location_id != location["id"]:
+                return False
         location["updated_at"] = self.get_timestamp()
         for i in range(len(self.data)):
             if self.data[i]["id"] == location_id:
                 self.data[i] = location
-                break
+                return True
 
     def remove_location(self, location_id):
         for x in self.data:

--- a/api/models/locations.py
+++ b/api/models/locations.py
@@ -1,6 +1,7 @@
 import json
 
 from models.base import Base
+from providers import data_provider
 
 LOCATIONS = []
 
@@ -46,6 +47,14 @@ class Locations(Base):
                 return True
 
     def remove_location(self, location_id):
+        location = self.get_location(location_id)
+        if location is None: return False
+        inventories = data_provider.fetch_inventory_pool().get_inventories()
+        for y in inventories:
+            for z in y["locations"]:
+                for a in z:
+                    if a == location:
+                        return False
         for x in self.data:
             if x["id"] == location_id:
                 self.data.remove(x)

--- a/api/models/locations.py
+++ b/api/models/locations.py
@@ -27,9 +27,13 @@ class Locations(Base):
         return result
 
     def add_location(self, location):
+        for x in self.data:
+            if x["id"] == location["id"]:
+                return False
         location["created_at"] = self.get_timestamp()
         location["updated_at"] = self.get_timestamp()
         self.data.append(location)
+        return True
 
     def update_location(self, location_id, location):
         location["updated_at"] = self.get_timestamp()

--- a/api/models/orders.py
+++ b/api/models/orders.py
@@ -31,7 +31,7 @@ class Orders(Base):
         result = []
         for x in self.data:
             if x["shipment_id"] == shipment_id:
-                result.append(x["id"])
+                result.append(x)
         return result
 
     def get_orders_for_client(self, client_id):

--- a/api/models/orders.py
+++ b/api/models/orders.py
@@ -51,11 +51,14 @@ class Orders(Base):
         return True
 
     def update_order(self, order_id, order):
+        if "id" in order:
+            if order_id != order["id"]:
+                return False
         order["updated_at"] = self.get_timestamp()
         for i in range(len(self.data)):
             if self.data[i]["id"] == order_id:
                 self.data[i] = order
-                break
+                return True
 
     def update_items_in_order(self, order_id, items):
         order = self.get_order(order_id)

--- a/api/models/orders.py
+++ b/api/models/orders.py
@@ -2,6 +2,7 @@ import json
 
 from models.base import Base
 from models.inventories import Inventories
+from providers import data_provider
 
 ORDERS = []
 
@@ -111,9 +112,12 @@ class Orders(Base):
             self.update_order(x, order)
 
     def remove_order(self, order_id):
+        order = self.get_order(order_id)
+        if order is None: return False
         for x in self.data:
             if x["id"] == order_id:
                 self.data.remove(x)
+                return True
 
     def load(self, is_debug):
         if is_debug:

--- a/api/models/orders.py
+++ b/api/models/orders.py
@@ -42,9 +42,13 @@ class Orders(Base):
         return result
 
     def add_order(self, order):
+        for x in self.data:
+            if x["id"] == order["id"]:
+                return False
         order["created_at"] = self.get_timestamp()
         order["updated_at"] = self.get_timestamp()
         self.data.append(order)
+        return True
 
     def update_order(self, order_id, order):
         order["updated_at"] = self.get_timestamp()

--- a/api/models/shipments.py
+++ b/api/models/shipments.py
@@ -37,11 +37,14 @@ class Shipments(Base):
         return True
 
     def update_shipment(self, shipment_id, shipment):
+        if "id" in shipment:
+            if shipment_id != shipment["id"]:
+                return False
         shipment["updated_at"] = self.get_timestamp()
         for i in range(len(self.data)):
             if self.data[i]["id"] == shipment_id:
                 self.data[i] = shipment
-                break
+                return True
 
     def update_items_in_shipment(self, shipment_id, items):
         shipment = self.get_shipment(shipment_id)
@@ -55,7 +58,7 @@ class Shipments(Base):
             if not found:
                 inventories = self.inventory.get_inventories_for_item(x["item_id"])
                 max_ordered = -1
-                max_inventory
+                max_inventory = max(inventories, key=lambda z: z["total_allocated"])
                 for z in inventories:
                     if z["total_ordered"] > max_ordered:
                         max_ordered = z["total_ordered"]
@@ -68,7 +71,7 @@ class Shipments(Base):
                 if x["item_id"] == y["item_id"]:
                     inventories = self.inventory.get_inventories_for_item(x["item_id"])
                     max_ordered = -1
-                    max_inventory
+                    max_inventory = max(inventories, key=lambda z: z["total_allocated"])
                     for z in inventories:
                         if z["total_ordered"] > max_ordered:
                             max_ordered = z["total_ordered"]

--- a/api/models/shipments.py
+++ b/api/models/shipments.py
@@ -2,6 +2,7 @@ import json
 
 from models.base import Base
 from models.inventories import Inventories
+from providers import data_provider
 
 SHIPMENTS = []
 
@@ -83,9 +84,16 @@ class Shipments(Base):
         self.update_shipment(shipment_id, shipment)
 
     def remove_shipment(self, shipment_id):
+        shipment = self.get_shipment(shipment_id)
+        if shipment is None: return False
+        orders = data_provider.fetch_order_pool().get_orders()
+        for y in orders:
+            if y["shipment_id"] == shipment_id:
+                return False
         for x in self.data:
             if x["id"] == shipment_id:
                 self.data.remove(x)
+                return True
 
     def load(self, is_debug):
         if is_debug:

--- a/api/models/shipments.py
+++ b/api/models/shipments.py
@@ -28,9 +28,13 @@ class Shipments(Base):
         return None
 
     def add_shipment(self, shipment):
+        for x in self.data:
+            if x["id"] == shipment["id"]:
+                return False
         shipment["created_at"] = self.get_timestamp()
         shipment["updated_at"] = self.get_timestamp()
         self.data.append(shipment)
+        return True
 
     def update_shipment(self, shipment_id, shipment):
         shipment["updated_at"] = self.get_timestamp()

--- a/api/models/suppliers.py
+++ b/api/models/suppliers.py
@@ -1,6 +1,7 @@
 import json
 
 from models.base import Base
+from providers import data_provider
 
 SUPPLIERS = []
 
@@ -39,9 +40,16 @@ class Suppliers(Base):
                 return True
 
     def remove_supplier(self, supplier_id):
+        supplier = self.get_supplier(supplier_id)
+        if supplier is None: return False
+        items = data_provider.fetch_item_pool().get_items()
+        for y in items:
+            if y["supplier_id"] == supplier_id:
+                return False
         for x in self.data:
             if x["id"] == supplier_id:
                 self.data.remove(x)
+                return True
 
     def load(self, is_debug):
         if is_debug:

--- a/api/models/suppliers.py
+++ b/api/models/suppliers.py
@@ -29,11 +29,14 @@ class Suppliers(Base):
         return True
 
     def update_supplier(self, supplier_id, supplier):
+        if "id" in supplier:
+            if supplier_id != supplier["id"]:
+                return False
         supplier["updated_at"] = self.get_timestamp()
         for i in range(len(self.data)):
             if self.data[i]["id"] == supplier_id:
                 self.data[i] = supplier
-                break
+                return True
 
     def remove_supplier(self, supplier_id):
         for x in self.data:

--- a/api/models/suppliers.py
+++ b/api/models/suppliers.py
@@ -20,9 +20,13 @@ class Suppliers(Base):
         return None
 
     def add_supplier(self, supplier):
+        for x in self.data:
+            if x["id"] == supplier["id"]:
+                return False
         supplier["created_at"] = self.get_timestamp()
         supplier["updated_at"] = self.get_timestamp()
         self.data.append(supplier)
+        return True
 
     def update_supplier(self, supplier_id, supplier):
         supplier["updated_at"] = self.get_timestamp()

--- a/api/models/transfers.py
+++ b/api/models/transfers.py
@@ -46,9 +46,12 @@ class Transfers(Base):
                 return True
 
     def remove_transfer(self, transfer_id):
+        transfer = self.get_transfer(transfer_id)
+        if transfer is None: return False
         for x in self.data:
             if x["id"] == transfer_id:
                 self.data.remove(x)
+                return True
 
     def load(self, is_debug):
         if is_debug:

--- a/api/models/transfers.py
+++ b/api/models/transfers.py
@@ -36,11 +36,14 @@ class Transfers(Base):
         return True
 
     def update_transfer(self, transfer_id, transfer):
+        if "id" in transfer:
+            if transfer_id != transfer["id"]:
+                return False
         transfer["updated_at"] = self.get_timestamp()
         for i in range(len(self.data)):
             if self.data[i]["id"] == transfer_id:
                 self.data[i] = transfer
-                break
+                return True
 
     def remove_transfer(self, transfer_id):
         for x in self.data:

--- a/api/models/transfers.py
+++ b/api/models/transfers.py
@@ -26,10 +26,14 @@ class Transfers(Base):
         return None
 
     def add_transfer(self, transfer):
+        for x in self.data:
+            if x["id"] == transfer["id"]:
+                return False
         transfer["transfer_status"] = "Scheduled"
         transfer["created_at"] = self.get_timestamp()
         transfer["updated_at"] = self.get_timestamp()
         self.data.append(transfer)
+        return True
 
     def update_transfer(self, transfer_id, transfer):
         transfer["updated_at"] = self.get_timestamp()

--- a/api/models/warehouses.py
+++ b/api/models/warehouses.py
@@ -20,9 +20,13 @@ class Warehouses(Base):
         return None
 
     def add_warehouse(self, warehouse):
+        for x in self.data:
+            if x["id"] == warehouse["id"]:
+                return False
         warehouse["created_at"] = self.get_timestamp()
         warehouse["updated_at"] = self.get_timestamp()
         self.data.append(warehouse)
+        return True
 
     def update_warehouse(self, warehouse_id, warehouse):
         warehouse["updated_at"] = self.get_timestamp()

--- a/api/models/warehouses.py
+++ b/api/models/warehouses.py
@@ -29,11 +29,14 @@ class Warehouses(Base):
         return True
 
     def update_warehouse(self, warehouse_id, warehouse):
+        if "id" in warehouse:
+            if warehouse_id != warehouse["id"]:
+                return False
         warehouse["updated_at"] = self.get_timestamp()
         for i in range(len(self.data)):
             if self.data[i]["id"] == warehouse_id:
                 self.data[i] = warehouse
-                break
+                return True
 
     def remove_warehouse(self, warehouse_id):
         for x in self.data:

--- a/api/models/warehouses.py
+++ b/api/models/warehouses.py
@@ -1,6 +1,7 @@
 import json
 
 from models.base import Base
+from providers import data_provider
 
 WAREHOUSES = []
 
@@ -39,9 +40,16 @@ class Warehouses(Base):
                 return True
 
     def remove_warehouse(self, warehouse_id):
+        warehouse = self.get_warehouse(warehouse_id)
+        if warehouse is None: return False
+        orders = data_provider.fetch_order_pool().get_orders()
+        for y in orders:
+            if y["warehouse_id"] == warehouse_id:
+                return False
         for x in self.data:
             if x["id"] == warehouse_id:
                 self.data.remove(x)
+                return True
 
     def load(self, is_debug):
         if is_debug:


### PR DESCRIPTION
wat er gefixt is in python v1:
GET: http://localhost:3000/api/v1/shipments/1/orders; wordt geen orderdetails geprint
POST: id kan 2x erin voorkomen, eerst checken of de id erin zit, vervolgens dan pas voegen als hij niet te vinden is.
POST: geen post for item_types, groups of lines.
PUT: wanneer je iets van id 1 wilt aanpassen, maar in de body zet je de id op 2, dan worden zowel de entities van id 1 en 2 aangepast. er moet gecheckt worden of de ids van de body en route wel overeen komen.
PUT: shipments/{shipment_id}/commit is nu een lege endpoint, moet aangevuld worden adhv van de andere commit endpoint 
DELETE: delete alleen mogelijk maken wanneer ander data niet afhankelijk is van het data dat gedeletet moet worden