### PR TITLE
Filtering feature 1.1

### DIFF
--- a/C#api/Controllers/ClientsController.cs
+++ b/C#api/Controllers/ClientsController.cs
@@ -40,6 +40,11 @@ public class ClientsController : BaseApiController
         try
         {
             var clients = DataProvider.fetch_client_pool().SearchClients(name, address, city, zipCode, province, country, contactName, contactPhone, contactEmail);
+            
+            if (clients == null || !clients.Any())
+            {
+                return NotFound("Error, er is geen Client(s) gevonden met deze gegevens.");
+            }
             return Ok(clients);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/ClientsController.cs
+++ b/C#api/Controllers/ClientsController.cs
@@ -24,15 +24,22 @@ public class ClientsController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchClients(
-        [FromQuery] string name, 
-        [FromQuery] string city, 
-        [FromQuery] string country)
+        [FromQuery] string name = null, 
+        [FromQuery] string city = null, 
+        [FromQuery] string country = null)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "clients", "get");
         if (auth != null) return auth;
 
-        var clients = DataProvider.fetch_client_pool().SearchClients(name, city, country);
-        return Ok(clients);
+        try
+        {
+            var clients = DataProvider.fetch_client_pool().SearchClients(name, city, country);
+            return Ok(clients);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
     }
 
     [HttpGet("{id}")]

--- a/C#api/Controllers/ClientsController.cs
+++ b/C#api/Controllers/ClientsController.cs
@@ -22,6 +22,19 @@ public class ClientsController : BaseApiController
         return Ok(clients);
     }
 
+    [HttpGet("search")]
+    public IActionResult SearchClients(
+        [FromQuery] string name, 
+        [FromQuery] string city, 
+        [FromQuery] string country)
+    {
+        var auth = CheckAuthorization(Request.Headers["API_KEY"], "clients", "get");
+        if (auth != null) return auth;
+
+        var clients = DataProvider.fetch_client_pool().SearchClients(name, city, country);
+        return Ok(clients);
+    }
+
     [HttpGet("{id}")]
     public IActionResult GetClient(int id)
     {

--- a/C#api/Controllers/ClientsController.cs
+++ b/C#api/Controllers/ClientsController.cs
@@ -24,6 +24,7 @@ public class ClientsController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchClients(
+        [FromQuery] int? id = null,
         [FromQuery] string name = null,
         [FromQuery] string address = null, 
         [FromQuery] string city = null,
@@ -39,7 +40,7 @@ public class ClientsController : BaseApiController
 
         try
         {
-            var clients = DataProvider.fetch_client_pool().SearchClients(name, address, city, zipCode, province, country, contactName, contactPhone, contactEmail);
+            var clients = DataProvider.fetch_client_pool().SearchClients(id,name, address, city, zipCode, province, country, contactName, contactPhone, contactEmail);
             
             if (clients == null || !clients.Any())
             {

--- a/C#api/Controllers/ClientsController.cs
+++ b/C#api/Controllers/ClientsController.cs
@@ -24,16 +24,22 @@ public class ClientsController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchClients(
-        [FromQuery] string name = null, 
-        [FromQuery] string city = null, 
-        [FromQuery] string country = null)
+        [FromQuery] string name = null,
+        [FromQuery] string address = null, 
+        [FromQuery] string city = null,
+        [FromQuery] string zipCode = null,
+        [FromQuery] string province = null,
+        [FromQuery] string country = null,
+        [FromQuery] string contactName = null,
+        [FromQuery] string contactPhone = null,
+        [FromQuery] string contactEmail = null)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "clients", "get");
         if (auth != null) return auth;
 
         try
         {
-            var clients = DataProvider.fetch_client_pool().SearchClients(name, city, country);
+            var clients = DataProvider.fetch_client_pool().SearchClients(name, address, city, zipCode, province, country, contactName, contactPhone, contactEmail);
             return Ok(clients);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/ItemsController.cs
+++ b/C#api/Controllers/ItemsController.cs
@@ -67,6 +67,30 @@ public class ItemsController : BaseApiController
         return Ok(totals);
     }
 
+    [HttpGet("search")]
+    public IActionResult SearchItems(
+        [FromQuery] string description, 
+        [FromQuery] string code, 
+        [FromQuery] string upcCode, 
+        [FromQuery] string modelNumber, 
+        [FromQuery] string commodityCode, 
+        [FromQuery] string supplierCode, 
+        [FromQuery] string supplierPartNumber)
+    {
+        var auth = CheckAuthorization(Request.Headers["API_KEY"], "items", "get");
+        if (auth != null) return auth;
+
+        var items = DataProvider.fetch_item_pool().SearchItems(
+            description, 
+            code, 
+            upcCode, 
+            modelNumber, 
+            commodityCode, 
+            supplierCode, 
+            supplierPartNumber);
+        return Ok(items);
+    }
+
     [HttpPost]
     public IActionResult CreateItem([FromBody] Item item)
     {

--- a/C#api/Controllers/ItemsController.cs
+++ b/C#api/Controllers/ItemsController.cs
@@ -69,6 +69,7 @@ public class ItemsController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchItems(
+        [FromQuery] string uid = null,
         [FromQuery] string description = null, 
         [FromQuery] string code = null, 
         [FromQuery] string upcCode = null, 
@@ -83,6 +84,7 @@ public class ItemsController : BaseApiController
         try
         {
             var items = DataProvider.fetch_item_pool().SearchItems(
+                uid,
                 description, 
                 code, 
                 upcCode, 

--- a/C#api/Controllers/ItemsController.cs
+++ b/C#api/Controllers/ItemsController.cs
@@ -69,26 +69,33 @@ public class ItemsController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchItems(
-        [FromQuery] string description, 
-        [FromQuery] string code, 
-        [FromQuery] string upcCode, 
-        [FromQuery] string modelNumber, 
-        [FromQuery] string commodityCode, 
-        [FromQuery] string supplierCode, 
-        [FromQuery] string supplierPartNumber)
+        [FromQuery] string description = null, 
+        [FromQuery] string code = null, 
+        [FromQuery] string upcCode = null, 
+        [FromQuery] string modelNumber = null, 
+        [FromQuery] string commodityCode = null, 
+        [FromQuery] string supplierCode = null, 
+        [FromQuery] string supplierPartNumber = null)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "items", "get");
         if (auth != null) return auth;
 
-        var items = DataProvider.fetch_item_pool().SearchItems(
-            description, 
-            code, 
-            upcCode, 
-            modelNumber, 
-            commodityCode, 
-            supplierCode, 
-            supplierPartNumber);
-        return Ok(items);
+        try
+        {
+            var items = DataProvider.fetch_item_pool().SearchItems(
+                description, 
+                code, 
+                upcCode, 
+                modelNumber, 
+                commodityCode, 
+                supplierCode, 
+                supplierPartNumber);
+            return Ok(items);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
     }
 
     [HttpPost]

--- a/C#api/Controllers/ItemsController.cs
+++ b/C#api/Controllers/ItemsController.cs
@@ -90,6 +90,12 @@ public class ItemsController : BaseApiController
                 commodityCode, 
                 supplierCode, 
                 supplierPartNumber);
+
+            if (items == null || !items.Any())
+            {
+                return NotFound("Error, er is geen Item(s) gevonden met deze gegevens.");
+            }
+            
             return Ok(items);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/LocationsController.cs
+++ b/C#api/Controllers/LocationsController.cs
@@ -63,6 +63,12 @@ public class LocationsController : BaseApiController
                 updated_At, 
                 warehouseId, 
                 code);
+            
+            if (locations == null || !locations.Any())
+            {
+                return NotFound("Error, er is geen Location(s) gevonden met deze gegevens.");
+            }
+
             return Ok(locations);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/LocationsController.cs
+++ b/C#api/Controllers/LocationsController.cs
@@ -46,6 +46,7 @@ public class LocationsController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchLocations(
+        [FromQuery] int? id = null,
         [FromQuery] string name = null, 
         [FromQuery] string created_At = null, 
         [FromQuery] string updated_At = null, 
@@ -58,6 +59,7 @@ public class LocationsController : BaseApiController
         try
         {
             var locations = DataProvider.fetch_location_pool().SearchLocations(
+                id,
                 name, 
                 created_At, 
                 updated_At, 

--- a/C#api/Controllers/LocationsController.cs
+++ b/C#api/Controllers/LocationsController.cs
@@ -46,17 +46,29 @@ public class LocationsController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchLocations(
-        [FromQuery] string name,
-        [FromQuery] string? created_At, 
-        [FromQuery] string? updated_At, 
-        [FromQuery] int? warehouseId, 
-        [FromQuery] string code)
+        [FromQuery] string name = null, 
+        [FromQuery] string created_At = null, 
+        [FromQuery] string updated_At = null, 
+        [FromQuery] int? warehouseId = null, 
+        [FromQuery] string code = null)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "locations", "get");
         if (auth != null) return auth;
 
-        var locations = DataProvider.fetch_location_pool().SearchLocations(name, created_At?.ToString(), updated_At, warehouseId, code);
-        return Ok(locations);
+        try
+        {
+            var locations = DataProvider.fetch_location_pool().SearchLocations(
+                name, 
+                created_At, 
+                updated_At, 
+                warehouseId, 
+                code);
+            return Ok(locations);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
     }
 
     [HttpPost]

--- a/C#api/Controllers/LocationsController.cs
+++ b/C#api/Controllers/LocationsController.cs
@@ -44,6 +44,21 @@ public class LocationsController : BaseApiController
         return Ok(inventory);
     }
 
+    [HttpGet("search")]
+    public IActionResult SearchLocations(
+        [FromQuery] string name,
+        [FromQuery] string? created_At, 
+        [FromQuery] string? updated_At, 
+        [FromQuery] int? warehouseId, 
+        [FromQuery] string code)
+    {
+        var auth = CheckAuthorization(Request.Headers["API_KEY"], "locations", "get");
+        if (auth != null) return auth;
+
+        var locations = DataProvider.fetch_location_pool().SearchLocations(name, created_At?.ToString(), updated_At, warehouseId, code);
+        return Ok(locations);
+    }
+
     [HttpPost]
     public IActionResult CreateLocation([FromBody] Location location)
     {

--- a/C#api/Controllers/OrdersController.cs
+++ b/C#api/Controllers/OrdersController.cs
@@ -58,28 +58,49 @@ public class OrdersController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchOrders(
-        [FromQuery] int sourceId,
-        [FromQuery] string orderDate,
-        [FromQuery] string requestDate,
-        [FromQuery] string reference,
-        [FromQuery] string referenceExtra,
-        [FromQuery] string orderStatus,
-        [FromQuery] string notes,
-        [FromQuery] string shippingNotes,
-        [FromQuery] string pickingNotes,
-        [FromQuery] int warehouseId,
-        [FromQuery] int shipTo,
-        [FromQuery] int billTo,
-        [FromQuery] int shipmentId,
-        [FromQuery] string created_At,
-        [FromQuery] string updated_At)
-
+        [FromQuery] int? sourceId = null,
+        [FromQuery] string orderStatus = null,
+        [FromQuery] string orderDate = null,
+        [FromQuery] string requestDate = null,
+        [FromQuery] string reference = null,
+        [FromQuery] string referenceExtra = null,
+        [FromQuery] string notes = null,
+        [FromQuery] string shippingNotes = null,
+        [FromQuery] string pickingNotes = null,
+        [FromQuery] int? warehouseId = null,
+        [FromQuery] int? shipTo = null,
+        [FromQuery] int? billTo = null,
+        [FromQuery] int? shipmentId = null,
+        [FromQuery] string created_At = null,
+        [FromQuery] string updated_At = null)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "orders", "get");
         if (auth != null) return auth;
 
-        var orders = DataProvider.fetch_order_pool().SearchOrders(sourceId, orderDate, requestDate, reference, referenceExtra, orderStatus, notes, shippingNotes, pickingNotes, warehouseId, shipTo, billTo, shipmentId, created_At, updated_At);
-        return Ok(orders);
+        try
+        {
+            var orders = DataProvider.fetch_order_pool().SearchOrders(
+                sourceId, 
+                orderStatus, 
+                orderDate, 
+                requestDate, 
+                reference, 
+                referenceExtra, 
+                notes, 
+                shippingNotes, 
+                pickingNotes, 
+                warehouseId, 
+                shipTo, 
+                billTo, 
+                shipmentId, 
+                created_At, 
+                updated_At);
+            return Ok(orders);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
     }
 
     [HttpPost]

--- a/C#api/Controllers/OrdersController.cs
+++ b/C#api/Controllers/OrdersController.cs
@@ -56,6 +56,32 @@ public class OrdersController : BaseApiController
         return Ok(order.Order_Status);
     }
 
+    [HttpGet("search")]
+    public IActionResult SearchOrders(
+        [FromQuery] int sourceId,
+        [FromQuery] string orderDate,
+        [FromQuery] string requestDate,
+        [FromQuery] string reference,
+        [FromQuery] string referenceExtra,
+        [FromQuery] string orderStatus,
+        [FromQuery] string notes,
+        [FromQuery] string shippingNotes,
+        [FromQuery] string pickingNotes,
+        [FromQuery] int warehouseId,
+        [FromQuery] int shipTo,
+        [FromQuery] int billTo,
+        [FromQuery] int shipmentId,
+        [FromQuery] string created_At,
+        [FromQuery] string updated_At)
+
+    {
+        var auth = CheckAuthorization(Request.Headers["API_KEY"], "orders", "get");
+        if (auth != null) return auth;
+
+        var orders = DataProvider.fetch_order_pool().SearchOrders(sourceId, orderDate, requestDate, reference, referenceExtra, orderStatus, notes, shippingNotes, pickingNotes, warehouseId, shipTo, billTo, shipmentId, created_At, updated_At);
+        return Ok(orders);
+    }
+
     [HttpPost]
     public IActionResult CreateOrder([FromBody] Order order)
     {

--- a/C#api/Controllers/OrdersController.cs
+++ b/C#api/Controllers/OrdersController.cs
@@ -58,6 +58,7 @@ public class OrdersController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchOrders(
+        [FromQuery] int? id = null, 
         [FromQuery] int? sourceId = null,
         [FromQuery] string orderStatus = null,
         [FromQuery] string orderDate = null,
@@ -80,6 +81,7 @@ public class OrdersController : BaseApiController
         try
         {
             var orders = DataProvider.fetch_order_pool().SearchOrders(
+                id,
                 sourceId, 
                 orderStatus, 
                 orderDate, 

--- a/C#api/Controllers/OrdersController.cs
+++ b/C#api/Controllers/OrdersController.cs
@@ -95,6 +95,12 @@ public class OrdersController : BaseApiController
                 shipmentId, 
                 created_At, 
                 updated_At);
+
+            if (orders == null || !orders.Any())
+            {
+                return NotFound("Error, er is geen Order(s) gevonden met deze gegevens.");
+            }
+
             return Ok(orders);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/ShipmentsController.cs
+++ b/C#api/Controllers/ShipmentsController.cs
@@ -74,8 +74,8 @@ public class ShipmentsController : BaseApiController
         [FromQuery] string requestDate = null,
         [FromQuery] string shipmentDate = null,
         [FromQuery] string shipmentType = null,
-        [FromQuery] string created_At = null,
-        [FromQuery] string updated_At = null)
+        [FromQuery] string shipmentStatus = null,
+        [FromQuery] string carrierCode = null)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "shipments", "get");
         if (auth != null) return auth;
@@ -89,8 +89,8 @@ public class ShipmentsController : BaseApiController
                 requestDate, 
                 shipmentDate, 
                 shipmentType, 
-                created_At, 
-                updated_At);
+                shipmentStatus, 
+                carrierCode);
             return Ok(shipments);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/ShipmentsController.cs
+++ b/C#api/Controllers/ShipmentsController.cs
@@ -91,6 +91,12 @@ public class ShipmentsController : BaseApiController
                 shipmentType, 
                 shipmentStatus, 
                 carrierCode);
+
+            if (shipments == null || !shipments.Any())
+            {
+                return NotFound("Error, er is geen Shipment(s) gevonden met deze gegevens.");
+            }
+
             return Ok(shipments);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/ShipmentsController.cs
+++ b/C#api/Controllers/ShipmentsController.cs
@@ -68,20 +68,35 @@ public class ShipmentsController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchShipments(
-        [FromQuery] string shipmentStatus, 
-        [FromQuery] string shipmentDate, 
-        [FromQuery] string requestDate, 
-        [FromQuery] int? orderId, 
-        [FromQuery] int? sourceId, 
-        [FromQuery] string carrierCode, 
-        [FromQuery] string serviceCode, 
-        [FromQuery] string paymentType)
+        [FromQuery] int? orderId = null,
+        [FromQuery] int? sourceId = null,
+        [FromQuery] string orderDate = null,
+        [FromQuery] string requestDate = null,
+        [FromQuery] string shipmentDate = null,
+        [FromQuery] string shipmentType = null,
+        [FromQuery] string created_At = null,
+        [FromQuery] string updated_At = null)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "shipments", "get");
         if (auth != null) return auth;
 
-        var shipments = DataProvider.fetch_shipment_pool().SearchShipments(shipmentStatus, shipmentDate, requestDate, orderId, sourceId, carrierCode, serviceCode, paymentType);
-        return Ok(shipments);
+        try
+        {
+            var shipments = DataProvider.fetch_shipment_pool().SearchShipments(
+                orderId, 
+                sourceId, 
+                orderDate, 
+                requestDate, 
+                shipmentDate, 
+                shipmentType, 
+                created_At, 
+                updated_At);
+            return Ok(shipments);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
     }
 
     [HttpPost]

--- a/C#api/Controllers/ShipmentsController.cs
+++ b/C#api/Controllers/ShipmentsController.cs
@@ -66,6 +66,24 @@ public class ShipmentsController : BaseApiController
         return Ok(shipment.Shipment_Status);
     }
 
+    [HttpGet("search")]
+    public IActionResult SearchShipments(
+        [FromQuery] string shipmentStatus, 
+        [FromQuery] string shipmentDate, 
+        [FromQuery] string requestDate, 
+        [FromQuery] int? orderId, 
+        [FromQuery] int? sourceId, 
+        [FromQuery] string carrierCode, 
+        [FromQuery] string serviceCode, 
+        [FromQuery] string paymentType)
+    {
+        var auth = CheckAuthorization(Request.Headers["API_KEY"], "shipments", "get");
+        if (auth != null) return auth;
+
+        var shipments = DataProvider.fetch_shipment_pool().SearchShipments(shipmentStatus, shipmentDate, requestDate, orderId, sourceId, carrierCode, serviceCode, paymentType);
+        return Ok(shipments);
+    }
+
     [HttpPost]
     public IActionResult CreateShipment([FromBody] Shipment shipment)
     {

--- a/C#api/Controllers/ShipmentsController.cs
+++ b/C#api/Controllers/ShipmentsController.cs
@@ -68,6 +68,7 @@ public class ShipmentsController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchShipments(
+        [FromQuery] int? id = null,
         [FromQuery] int? orderId = null,
         [FromQuery] int? sourceId = null,
         [FromQuery] string orderDate = null,
@@ -83,6 +84,7 @@ public class ShipmentsController : BaseApiController
         try
         {
             var shipments = DataProvider.fetch_shipment_pool().SearchShipments(
+                id,
                 orderId, 
                 sourceId, 
                 orderDate, 

--- a/C#api/Controllers/SuppliersController.cs
+++ b/C#api/Controllers/SuppliersController.cs
@@ -46,17 +46,29 @@ public class SuppliersController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchSuppliers(
-        [FromQuery] string name, 
-        [FromQuery] string city, 
-        [FromQuery] string country,
-        [FromQuery] string code, 
-        [FromQuery] string reference)
+        [FromQuery] string name = null, 
+        [FromQuery] string city = null, 
+        [FromQuery] string country = null,
+        [FromQuery] string code = null, 
+        [FromQuery] string reference = null)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "suppliers", "get");
         if (auth != null) return auth;
 
-        var suppliers = DataProvider.fetch_supplier_pool().SearchSuppliers(name, city, country, code, reference);
-        return Ok(suppliers);
+        try
+        {
+            var suppliers = DataProvider.fetch_supplier_pool().SearchSuppliers(
+                name, 
+                city, 
+                country, 
+                code, 
+                reference);
+            return Ok(suppliers);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
     }
 
     [HttpPost]

--- a/C#api/Controllers/SuppliersController.cs
+++ b/C#api/Controllers/SuppliersController.cs
@@ -44,6 +44,19 @@ public class SuppliersController : BaseApiController
         return Ok(items);
     }
 
+    [HttpGet("search")]
+    public IActionResult SearchSuppliers(
+        [FromQuery] string name, 
+        [FromQuery] string city, 
+        [FromQuery] string country)
+    {
+        var auth = CheckAuthorization(Request.Headers["API_KEY"], "suppliers", "get");
+        if (auth != null) return auth;
+
+        var suppliers = DataProvider.fetch_supplier_pool().SearchSuppliers(name, city, country);
+        return Ok(suppliers);
+    }
+
     [HttpPost]
     public IActionResult CreateSupplier([FromBody] Supplier supplier)
     {

--- a/C#api/Controllers/SuppliersController.cs
+++ b/C#api/Controllers/SuppliersController.cs
@@ -46,6 +46,7 @@ public class SuppliersController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchSuppliers(
+        [FromQuery] int? id = null,
         [FromQuery] string name = null, 
         [FromQuery] string city = null, 
         [FromQuery] string country = null,
@@ -58,6 +59,7 @@ public class SuppliersController : BaseApiController
         try
         {
             var suppliers = DataProvider.fetch_supplier_pool().SearchSuppliers(
+                id,
                 name, 
                 city, 
                 country, 

--- a/C#api/Controllers/SuppliersController.cs
+++ b/C#api/Controllers/SuppliersController.cs
@@ -63,6 +63,12 @@ public class SuppliersController : BaseApiController
                 country, 
                 code, 
                 reference);
+
+            if (suppliers == null || !suppliers.Any())
+            {
+                return NotFound("Error, er is geen Supplier(s) gevonden met deze gegevens.");
+            }
+
             return Ok(suppliers);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/SuppliersController.cs
+++ b/C#api/Controllers/SuppliersController.cs
@@ -48,12 +48,14 @@ public class SuppliersController : BaseApiController
     public IActionResult SearchSuppliers(
         [FromQuery] string name, 
         [FromQuery] string city, 
-        [FromQuery] string country)
+        [FromQuery] string country,
+        [FromQuery] string code, 
+        [FromQuery] string reference)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "suppliers", "get");
         if (auth != null) return auth;
 
-        var suppliers = DataProvider.fetch_supplier_pool().SearchSuppliers(name, city, country);
+        var suppliers = DataProvider.fetch_supplier_pool().SearchSuppliers(name, city, country, code, reference);
         return Ok(suppliers);
     }
 

--- a/C#api/Controllers/TransfersController.cs
+++ b/C#api/Controllers/TransfersController.cs
@@ -58,17 +58,29 @@ public class TransfersController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchTransfers(
-        [FromQuery] string reference,
-        [FromQuery] int? transferFrom,
-        [FromQuery] int? transferTo,
-        [FromQuery] string transferStatus,
-        [FromQuery] string createdAt)
+        [FromQuery] string reference = null,
+        [FromQuery] int? transferFrom = null,
+        [FromQuery] int? transferTo = null,
+        [FromQuery] string transferStatus = null,
+        [FromQuery] string createdAt = null)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "transfers", "get");
         if (auth != null) return auth;
 
-        var transfers = DataProvider.fetch_transfer_pool().SearchTransfers(reference, transferFrom, transferTo, transferStatus, createdAt);
-        return Ok(transfers);
+        try
+        {
+            var transfers = DataProvider.fetch_transfer_pool().SearchTransfers(
+                reference, 
+                transferFrom, 
+                transferTo, 
+                transferStatus, 
+                createdAt);
+            return Ok(transfers);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
     }
 
     [HttpPost]

--- a/C#api/Controllers/TransfersController.cs
+++ b/C#api/Controllers/TransfersController.cs
@@ -56,6 +56,21 @@ public class TransfersController : BaseApiController
         return Ok(transfer.Transfer_Status);
     }
 
+    [HttpGet("search")]
+    public IActionResult SearchTransfers(
+        [FromQuery] string reference,
+        [FromQuery] int? transferFrom,
+        [FromQuery] int? transferTo,
+        [FromQuery] string transferStatus,
+        [FromQuery] string createdAt)
+    {
+        var auth = CheckAuthorization(Request.Headers["API_KEY"], "transfers", "get");
+        if (auth != null) return auth;
+
+        var transfers = DataProvider.fetch_transfer_pool().SearchTransfers(reference, transferFrom, transferTo, transferStatus, createdAt);
+        return Ok(transfers);
+    }
+
     [HttpPost]
     public IActionResult CreateTransfer([FromBody] Transfer transfer)
     {

--- a/C#api/Controllers/TransfersController.cs
+++ b/C#api/Controllers/TransfersController.cs
@@ -75,6 +75,12 @@ public class TransfersController : BaseApiController
                 transferTo, 
                 transferStatus, 
                 createdAt);
+
+            if (transfers == null || !transfers.Any())
+            {
+                return NotFound("Error, er is geen Transfer(s) gevonden met deze gegevens.");
+            }
+
             return Ok(transfers);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/TransfersController.cs
+++ b/C#api/Controllers/TransfersController.cs
@@ -58,6 +58,7 @@ public class TransfersController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchTransfers(
+        [FromQuery] int? id = null,
         [FromQuery] string reference = null,
         [FromQuery] int? transferFrom = null,
         [FromQuery] int? transferTo = null,
@@ -70,6 +71,7 @@ public class TransfersController : BaseApiController
         try
         {
             var transfers = DataProvider.fetch_transfer_pool().SearchTransfers(
+                id,
                 reference, 
                 transferFrom, 
                 transferTo, 

--- a/C#api/Controllers/WarehousesController.cs
+++ b/C#api/Controllers/WarehousesController.cs
@@ -46,6 +46,7 @@ public class WarehousesController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchWarehouses(
+        [FromQuery] int? id = null,
         [FromQuery] string code = null, 
         [FromQuery] string name = null, 
         [FromQuery] string address = null,
@@ -62,6 +63,7 @@ public class WarehousesController : BaseApiController
         try
         {
             var warehouses = DataProvider.fetch_warehouse_pool().SearchWarehouses(
+                id,
                 code, 
                 name, 
                 address, 

--- a/C#api/Controllers/WarehousesController.cs
+++ b/C#api/Controllers/WarehousesController.cs
@@ -46,22 +46,37 @@ public class WarehousesController : BaseApiController
 
     [HttpGet("search")]
     public IActionResult SearchWarehouses(
-        [FromQuery] string code, 
-        [FromQuery] string name, 
-        [FromQuery] string address,
-        [FromQuery] string zip,
-        [FromQuery] string city,
-        [FromQuery] string provincie,
-        [FromQuery] string country,
-        [FromQuery] ContactInfo contact,
-        [FromQuery] string createdAt,
-        [FromQuery] string updatedAt)
+        [FromQuery] string code = null, 
+        [FromQuery] string name = null, 
+        [FromQuery] string address = null,
+        [FromQuery] string zip = null,
+        [FromQuery] string city = null,
+        [FromQuery] string province = null,
+        [FromQuery] string country = null,
+        [FromQuery] string createdAt = null,
+        [FromQuery] string updatedAt = null)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "warehouses", "get");
         if (auth != null) return auth;
 
-        var warehouses = DataProvider.fetch_warehouse_pool().SearchWarehouses(code, name, address, zip, city, provincie, country, contact, createdAt, updatedAt);
-        return Ok(warehouses);
+        try
+        {
+            var warehouses = DataProvider.fetch_warehouse_pool().SearchWarehouses(
+                code, 
+                name, 
+                address, 
+                zip, 
+                city, 
+                province, 
+                country, 
+                createdAt, 
+                updatedAt);
+            return Ok(warehouses);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
     }
 
 

--- a/C#api/Controllers/WarehousesController.cs
+++ b/C#api/Controllers/WarehousesController.cs
@@ -44,6 +44,27 @@ public class WarehousesController : BaseApiController
         return Ok(locations);
     }
 
+    [HttpGet("search")]
+    public IActionResult SearchWarehouses(
+        [FromQuery] string code, 
+        [FromQuery] string name, 
+        [FromQuery] string address,
+        [FromQuery] string zip,
+        [FromQuery] string city,
+        [FromQuery] string provincie,
+        [FromQuery] string country,
+        [FromQuery] ContactInfo contact,
+        [FromQuery] string createdAt,
+        [FromQuery] string updatedAt)
+    {
+        var auth = CheckAuthorization(Request.Headers["API_KEY"], "warehouses", "get");
+        if (auth != null) return auth;
+
+        var warehouses = DataProvider.fetch_warehouse_pool().SearchWarehouses(code, name, address, zip, city, provincie, country, contact, createdAt, updatedAt);
+        return Ok(warehouses);
+    }
+
+
     // [HttpGet("{id}/inventory")]
     // public IActionResult GetWarehouseInventory(int id)
     // {

--- a/C#api/Controllers/WarehousesController.cs
+++ b/C#api/Controllers/WarehousesController.cs
@@ -71,6 +71,12 @@ public class WarehousesController : BaseApiController
                 country, 
                 createdAt, 
                 updatedAt);
+            
+            if (warehouses == null || !warehouses.Any())
+            {
+                return NotFound("Error, er is geen Warehouse(s) gevonden met deze gegevens.");
+            }
+
             return Ok(warehouses);
         }
         catch (ArgumentException ex)

--- a/C#api/Tests/test_clients.py
+++ b/C#api/Tests/test_clients.py
@@ -65,39 +65,51 @@ class ApiClientsTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
     
     def test_search_by_name(self):
-        response = self.client.get(f"clients?name=John")
+        response = self.client.get(f"clients?name=Raymond Inc")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Name'], "Raymond Inc")
     
     def test_search_by_city(self):
-        response = self.client.get(f"clients?city=Anytown")
+        response = self.client.get(f"clients?city=Pierceview")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['City'], "Pierceview")
     
     def test_search_by_country(self):
-        response = self.client.get(f"clients?country=Country")
+        response = self.client.get(f"clients?country=United States")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Country'], "United States")
     
     def test_search_by_name_and_city(self):
-        response = self.client.get(f"clients?name=John&city=Anytown")
+        response = self.client.get(f"clients?name=Raymond Inc&city=Pierceview")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Name'], "Raymond Inc")
+        self.assertEqual(response.json()[0]['City'], "Pierceview")
     
     def test_search_by_name_and_country(self):
-        response = self.client.get(f"clients?name=John&country=Country")
+        response = self.client.get(f"clients?name=Raymond Inc&country=United States")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Name'], "Raymond Inc")
+        self.assertEqual(response.json()[0]['Country'], "United States")
     
     def test_search_by_city_and_country(self):
-        response = self.client.get(f"clients?city=Anytown&country=Country")
+        response = self.client.get(f"clients?city=Pierceview&country=United States")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['City'], "Pierceview")
+        self.assertEqual(response.json()[0]['Country'], "United States")
     
     def test_search_by_name_and_city_and_country(self):
-        response = self.client.get(f"clients?name=John&city=Anytown&country=Country")
+        response = self.client.get(f"clients?name=Raymond Inc&city=Pierceview&country=United States")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Name'], "Raymond Inc")
+        self.assertEqual(response.json()[0]['City'], "Pierceview")
+        self.assertEqual(response.json()[0]['Country'], "United States")
     
 
     # POST tests

--- a/C#api/Tests/test_clients.py
+++ b/C#api/Tests/test_clients.py
@@ -63,6 +63,42 @@ class ApiClientsTests(unittest.TestCase):
     def test_3get_non_existent_client(self):
         response = self.client.get("clients/-1")
         self.assertEqual(response.status_code, 404)
+    
+    def test_search_by_name(self):
+        response = self.client.get(f"clients?name=John")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_by_city(self):
+        response = self.client.get(f"clients?city=Anytown")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_by_country(self):
+        response = self.client.get(f"clients?country=Country")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_by_name_and_city(self):
+        response = self.client.get(f"clients?name=John&city=Anytown")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_by_name_and_country(self):
+        response = self.client.get(f"clients?name=John&country=Country")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_by_city_and_country(self):
+        response = self.client.get(f"clients?city=Anytown&country=Country")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_by_name_and_city_and_country(self):
+        response = self.client.get(f"clients?name=John&city=Anytown&country=Country")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
 
     # POST tests
 

--- a/C#api/Tests/test_clients.py
+++ b/C#api/Tests/test_clients.py
@@ -67,51 +67,59 @@ class ApiClientsTests(unittest.TestCase):
     def test_search_by_name(self):
         response = self.client.get(f"clients?name=Raymond Inc")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Name'], "Raymond Inc")
+        self.assertTrue(len(response.json()) > 0, response.json())
+        for name in response.json():
+            if name['Name'] != "Raymond Inc":
+                break
     
     def test_search_by_city(self):
         response = self.client.get(f"clients?city=Pierceview")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['City'], "Pierceview")
-    
+        for city in response.json():
+            if city['City'] != "Pierceview":
+                break
+                
     def test_search_by_country(self):
         response = self.client.get(f"clients?country=United States")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Country'], "United States")
+        for country in response.json():
+            if country['Country'] != "United States":
+                break
     
     def test_search_by_name_and_city(self):
         response = self.client.get(f"clients?name=Raymond Inc&city=Pierceview")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Name'], "Raymond Inc")
-        self.assertEqual(response.json()[0]['City'], "Pierceview")
+        for x in response.json():
+            if x['Name'] != "Raymond Inc" or x['City'] != "Pierceview":
+                break
     
     def test_search_by_name_and_country(self):
         response = self.client.get(f"clients?name=Raymond Inc&country=United States")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Name'], "Raymond Inc")
-        self.assertEqual(response.json()[0]['Country'], "United States")
+        for x in response.json():
+            if x['Name'] != "Raymond Inc" or x['Country'] != "United States":
+                break
     
     def test_search_by_city_and_country(self):
         response = self.client.get(f"clients?city=Pierceview&country=United States")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['City'], "Pierceview")
-        self.assertEqual(response.json()[0]['Country'], "United States")
+        for x in response.json():
+            if x['City'] != "Pierceview" or x['Country'] != "United States":
+                break
     
     def test_search_by_name_and_city_and_country(self):
         response = self.client.get(f"clients?name=Raymond Inc&city=Pierceview&country=United States")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Name'], "Raymond Inc")
-        self.assertEqual(response.json()[0]['City'], "Pierceview")
-        self.assertEqual(response.json()[0]['Country'], "United States")
+        for x in response.json():
+            if x['Name'] != "Raymond Inc" or x['City'] != "Pierceview" or x['Country'] != "United States":
+                break
     
-
     # POST tests
 
     def test_4create_client(self):

--- a/C#api/Tests/test_clients.py
+++ b/C#api/Tests/test_clients.py
@@ -65,60 +65,61 @@ class ApiClientsTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
     
     def test_search_by_name(self):
-        response = self.client.get(f"clients?name=Raymond Inc")
+        response = self.client.get(f"clients/search?name=Raymond Inc")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(len(response.json()) > 0, response.json()[0])
         for name in response.json():
-            if name['Name'] != "Raymond Inc":
-                break
+            self.assertEqual(name['Name'], "Raymond Inc")
     
     def test_search_by_city(self):
-        response = self.client.get(f"clients?city=Pierceview")
+        response = self.client.get(f"clients/search?city=Pierceview")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(len(response.json()) > 0, response.json()[0])
         for city in response.json():
-            if city['City'] != "Pierceview":
-                break
+            if self.assertEqual(city['City'], "Pierceview"):
+                return city
+            else:
+                return False
                 
     def test_search_by_country(self):
-        response = self.client.get(f"clients?country=United States")
+        response = self.client.get(f"clients/search?country=United States")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for country in response.json():
-            if country['Country'] != "United States":
-                break
+            self.assertEqual(country['Country'], "United States")
     
     def test_search_by_name_and_city(self):
-        response = self.client.get(f"clients?name=Raymond Inc&city=Pierceview")
+        response = self.client.get(f"clients/search?name=Raymond Inc&city=Pierceview")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            if x['Name'] != "Raymond Inc" or x['City'] != "Pierceview":
-                break
+            self.assertEqual(x['Name'], "Raymond Inc")
+            self.assertEqual(x['City'], "Pierceview")
     
     def test_search_by_name_and_country(self):
-        response = self.client.get(f"clients?name=Raymond Inc&country=United States")
+        response = self.client.get(f"clients/search?name=Raymond Inc&country=United States")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            if x['Name'] != "Raymond Inc" or x['Country'] != "United States":
-                break
+            self.assertEqual(x['Name'], "Raymond Inc")
+            self.assertEqual(x['Country'], "United States")
     
     def test_search_by_city_and_country(self):
-        response = self.client.get(f"clients?city=Pierceview&country=United States")
+        response = self.client.get(f"clients/search?city=Pierceview&country=United States")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            if x['City'] != "Pierceview" or x['Country'] != "United States":
-                break
+            self.assertEqual(x['City'], "Pierceview")
+            self.assertEqual(x['Country'], "United States")
     
     def test_search_by_name_and_city_and_country(self):
-        response = self.client.get(f"clients?name=Raymond Inc&city=Pierceview&country=United States")
+        response = self.client.get(f"clients/search?name=Raymond Inc&city=Pierceview&country=United States")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            if x['Name'] != "Raymond Inc" or x['City'] != "Pierceview" or x['Country'] != "United States":
-                break
+            self.assertEqual(x['Name'], "Raymond Inc")
+            self.assertEqual(x['City'], "Pierceview")
+            self.assertEqual(x['Country'], "United States")
     
     # POST tests
 

--- a/C#api/Tests/test_items.py
+++ b/C#api/Tests/test_items.py
@@ -103,7 +103,20 @@ class ApiItemsTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0)
     
+    def test_search_items_by_code_and_supplier_part_number(self):
+        response = self.client.get("items?code=P000001&supplier_part_number=SUP123-PART001")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
     
+    def test_search_items_by_description_and_upc_code(self):
+        response = self.client.get("items?description=Widget&upc_code=123456789012")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_items_by_model_number_and_commodity_code(self):
+        response = self.client.get("items?model_number=MODEL123&commodity_code=COMMOD123")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
 
     # POST tests
     def test_4create_item(self):

--- a/C#api/Tests/test_items.py
+++ b/C#api/Tests/test_items.py
@@ -87,59 +87,59 @@ class ApiItemsTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            self.assertEqual(item['Upc_Code'] == "6523540947122")
+            self.assertEqual(item['Upc_Code'], "6523540947122")
     
     def test_search_items_by_model_number(self):
         response = self.client.get("items/search?model_number=63-OFFTq0T")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            self.assertEqual(item['Model_Number'] == "63-OFFTq0T")
+            self.assertEqual(item['Model_Number'], "63-OFFTq0T")
     
     def test_search_items_by_commodity_code(self):
-        response = self.client.get("items/search?commodity_code=oTo304")
+        response = self.client.get("items/search?commodity_code=y-20588-owy")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            self.assertEqual(item['Commodity_Code'] == "oTo304")
+            self.assertEqual(item['Commodity_Code'], "y-20588-owy")
     
     def test_search_items_by_supplier_code(self):
         response = self.client.get("items/search?supplier_code=SUP423")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            self.assertEqual(item.supplier_code == "SUP423")
+            self.assertEqual(item['Supplier_Code'], "SUP423")
     
     def test_search_items_by_supplier_part_number(self):
         response = self.client.get("items/search?supplier_part_number=E-86805-uTM")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            self.assertEqual(item.supplier_part_number == "E-86805-uTM")
+            self.assertEqual(item['Supplier_Part_Number'], "E-86805-uTM")
     
     def test_search_items_by_code_and_supplier_part_number(self):
         response = self.client.get("items/search?code=sjQ23408K&supplier_part_number=E-86805-uTM")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            self.assertEqual(item.code == "sjQ23408K")
-            self.assertEqual(item.supplier_part_number == "E-86805-uTM")
+            self.assertEqual(item['Code'], "sjQ23408K")
+            self.assertEqual(item['Supplier_Part_Number'], "E-86805-uTM")
     
     def test_search_items_by_description_and_upc_code(self):
         response = self.client.get("items/search?description=Face-to-face clear-thinking complexity&upc_code=6523540947122")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            self.assertEqual(item.description == "Face-to-face clear-thinking complexity")
-            self.assertEqual(item.upc_code == "6523540947122")
+            self.assertEqual(item ['Description'], "Face-to-face clear-thinking complexity")
+            self.assertEqual(item ['Upc_Code'], "6523540947122")
     
     def test_search_items_by_model_number_and_commodity_code(self):
         response = self.client.get("items/search?model_number=63-OFFTq0T&commodity_code=oTo304")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            self.assertEqual(item['Model_Number'] == "63-OFFTq0T")
-            self.assertEqual(item['Commodity_Code'] == "oTo304")
+            self.assertEqual(item['Model_Number'], "63-OFFTq0T")
+            self.assertEqual(item['Commodity_Code'], "oTo304")
             
     # POST tests
     def test_4create_item(self):

--- a/C#api/Tests/test_items.py
+++ b/C#api/Tests/test_items.py
@@ -83,35 +83,35 @@ class ApiItemsTests(unittest.TestCase):
             self.assertEqual(description['Description'], "Face-to-face clear-thinking complexity")
     
     def test_search_items_by_upc_code(self):
-        response = self.client.get("items/search?upc_code=6523540947122")
+        response = self.client.get("items/search?upccode=6523540947122")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
             self.assertEqual(item['Upc_Code'], "6523540947122")
     
     def test_search_items_by_model_number(self):
-        response = self.client.get("items/search?model_number=63-OFFTq0T")
+        response = self.client.get("items/search?modelnumber=63-OFFTq0T")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
             self.assertEqual(item['Model_Number'], "63-OFFTq0T")
     
     def test_search_items_by_commodity_code(self):
-        response = self.client.get("items/search?commodity_code=y-20588-owy")
+        response = self.client.get("items/search?commoditycode=oTo304")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            self.assertEqual(item['Commodity_Code'], "y-20588-owy")
+            self.assertEqual(item['Commodity_Code'], "oTo304")
     
     def test_search_items_by_supplier_code(self):
-        response = self.client.get("items/search?supplier_code=SUP423")
+        response = self.client.get("items/search?suppliercode=SUP423")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
             self.assertEqual(item['Supplier_Code'], "SUP423")
     
     def test_search_items_by_supplier_part_number(self):
-        response = self.client.get("items/search?supplier_part_number=E-86805-uTM")
+        response = self.client.get("items/search?supplierpartnumber=E-86805-uTM")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
@@ -134,7 +134,7 @@ class ApiItemsTests(unittest.TestCase):
             self.assertEqual(item ['Upc_Code'], "6523540947122")
     
     def test_search_items_by_model_number_and_commodity_code(self):
-        response = self.client.get("items/search?model_number=63-OFFTq0T&commodity_code=oTo304")
+        response = self.client.get("items/search?modelnumber=63-OFFTq0T&commoditycode=oTo304")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():

--- a/C#api/Tests/test_items.py
+++ b/C#api/Tests/test_items.py
@@ -72,64 +72,81 @@ class ApiItemsTests(unittest.TestCase):
         response = self.client.get("items?code=sjQ23408K")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Code'] == "sjQ23408K")
+        for code in response.json():
+            if code['Code'] != "sjQ23408K":
+                break
     
     def test_search_items_by_description(self):
         response = self.client.get("items?description=Face-to-face clear-thinking complexity")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Description'] == "Face-to-face clear-thinking complexity")
+        for description in response.json():
+            if description['Description'] != "Face-to-face clear-thinking complexity":
+                break
     
     def test_search_items_by_upc_code(self):
         response = self.client.get("items?upc_code=6523540947122")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Upc_Code'] == "6523540947122")
+        for item in response.json():
+            if item['Upc_Code'] != "6523540947122":
+                break
     
     def test_search_items_by_model_number(self):
         response = self.client.get("items?model_number=63-OFFTq0T")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Model_Number'] == "63-OFFTq0T")
+        for item in response.json():
+            if item['Model_Number'] != "63-OFFTq0T":
+                break
     
     def test_search_items_by_commodity_code(self):
         response = self.client.get("items?commodity_code=oTo304")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Commodity_Code'] == "oTo304")
+        for item in response.json():
+            if item['Commodity_Code'] != "oTo304":
+                break
     
     def test_search_items_by_supplier_code(self):
         response = self.client.get("items?supplier_code=SUP423")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Supplier_Code'] == "SUP423")
+        for item in response.json():
+            if item['Supplier_Code'] != "SUP423":
+                break
     
     def test_search_items_by_supplier_part_number(self):
         response = self.client.get("items?supplier_part_number=E-86805-uTM")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Supplier_Part_Number'] == "E-86805-uTM")
+        for item in response.json():
+            if item['Supplier_Part_Number'] != "E-86805-uTM":
+                break
     
     def test_search_items_by_code_and_supplier_part_number(self):
         response = self.client.get("items?code=sjQ23408K&supplier_part_number=E-86805-uTM")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Code'] == "sjQ23408K")
+        for item in response.json():
+            if item['Code'] != "sjQ23408K" or item['Supplier_Part_Number'] != "E-86805-uTM":
+                break
     
     def test_search_items_by_description_and_upc_code(self):
         response = self.client.get("items?description=Face-to-face clear-thinking complexity&upc_code=6523540947122")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Description'] == "Face-to-face clear-thinking complexity")
-        self.assertTrue(response.json()[0]['Upc_Code'] == "6523540947122")
+        for item in response.json():
+            if item['Description'] != "Face-to-face clear-thinking complexity" or item['Upc_Code'] != "6523540947122":
+                break
     
     def test_search_items_by_model_number_and_commodity_code(self):
         response = self.client.get("items?model_number=63-OFFTq0T&commodity_code=oTo304")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Model_Number'] == "63-OFFTq0T")
-        self.assertTrue(response.json()[0]['Commodity_Code'] == "oTo304")
-
+        for item in response.json():
+            if item['Model_Number'] != "63-OFFTq0T" or item['Commodity_Code'] != "oTo304":
+                break
     # POST tests
     def test_4create_item(self):
         response = self.client.post("items", json=self.new_item)

--- a/C#api/Tests/test_items.py
+++ b/C#api/Tests/test_items.py
@@ -69,54 +69,66 @@ class ApiItemsTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
     
     def test_search_items_by_code(self):
-        response = self.client.get("items?code=P000001")
+        response = self.client.get("items?code=sjQ23408K")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Code'] == "sjQ23408K")
     
     def test_search_items_by_description(self):
-        response = self.client.get("items?description=Widget")
+        response = self.client.get("items?description=Face-to-face clear-thinking complexity")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Description'] == "Face-to-face clear-thinking complexity")
     
     def test_search_items_by_upc_code(self):
-        response = self.client.get("items?upc_code=123456789012")
+        response = self.client.get("items?upc_code=6523540947122")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Upc_Code'] == "6523540947122")
     
     def test_search_items_by_model_number(self):
-        response = self.client.get("items?model_number=MODEL123")
+        response = self.client.get("items?model_number=63-OFFTq0T")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Model_Number'] == "63-OFFTq0T")
     
     def test_search_items_by_commodity_code(self):
-        response = self.client.get("items?commodity_code=COMMOD123")
+        response = self.client.get("items?commodity_code=oTo304")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Commodity_Code'] == "oTo304")
     
     def test_search_items_by_supplier_code(self):
-        response = self.client.get("items?supplier_code=SUP123")
+        response = self.client.get("items?supplier_code=SUP423")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Supplier_Code'] == "SUP423")
     
     def test_search_items_by_supplier_part_number(self):
-        response = self.client.get("items?supplier_part_number=SUP123-PART001")
+        response = self.client.get("items?supplier_part_number=E-86805-uTM")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Supplier_Part_Number'] == "E-86805-uTM")
     
     def test_search_items_by_code_and_supplier_part_number(self):
-        response = self.client.get("items?code=P000001&supplier_part_number=SUP123-PART001")
+        response = self.client.get("items?code=sjQ23408K&supplier_part_number=E-86805-uTM")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Code'] == "sjQ23408K")
     
     def test_search_items_by_description_and_upc_code(self):
-        response = self.client.get("items?description=Widget&upc_code=123456789012")
+        response = self.client.get("items?description=Face-to-face clear-thinking complexity&upc_code=6523540947122")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Description'] == "Face-to-face clear-thinking complexity")
+        self.assertTrue(response.json()[0]['Upc_Code'] == "6523540947122")
     
     def test_search_items_by_model_number_and_commodity_code(self):
-        response = self.client.get("items?model_number=MODEL123&commodity_code=COMMOD123")
+        response = self.client.get("items?model_number=63-OFFTq0T&commodity_code=oTo304")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Model_Number'] == "63-OFFTq0T")
+        self.assertTrue(response.json()[0]['Commodity_Code'] == "oTo304")
 
     # POST tests
     def test_4create_item(self):

--- a/C#api/Tests/test_items.py
+++ b/C#api/Tests/test_items.py
@@ -67,6 +67,43 @@ class ApiItemsTests(unittest.TestCase):
     def test_get_item_locations(self):
         response = self.client.get("items/P000001/locations")
         self.assertEqual(response.status_code, 200)
+    
+    def test_search_items_by_code(self):
+        response = self.client.get("items?code=P000001")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_items_by_description(self):
+        response = self.client.get("items?description=Widget")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_items_by_upc_code(self):
+        response = self.client.get("items?upc_code=123456789012")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_items_by_model_number(self):
+        response = self.client.get("items?model_number=MODEL123")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_items_by_commodity_code(self):
+        response = self.client.get("items?commodity_code=COMMOD123")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_items_by_supplier_code(self):
+        response = self.client.get("items?supplier_code=SUP123")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_items_by_supplier_part_number(self):
+        response = self.client.get("items?supplier_part_number=SUP123-PART001")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    
 
     # POST tests
     def test_4create_item(self):

--- a/C#api/Tests/test_items.py
+++ b/C#api/Tests/test_items.py
@@ -69,84 +69,78 @@ class ApiItemsTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
     
     def test_search_items_by_code(self):
-        response = self.client.get("items?code=sjQ23408K")
+        response = self.client.get("items/search?code=sjQ23408K")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for code in response.json():
-            if code['Code'] != "sjQ23408K":
-                break
+            self.assertEqual(code['Code'], "sjQ23408K")
     
     def test_search_items_by_description(self):
-        response = self.client.get("items?description=Face-to-face clear-thinking complexity")
+        response = self.client.get("items/search?description=Face-to-face clear-thinking complexity")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for description in response.json():
-            if description['Description'] != "Face-to-face clear-thinking complexity":
-                break
+            self.assertEqual(description['Description'], "Face-to-face clear-thinking complexity")
     
     def test_search_items_by_upc_code(self):
-        response = self.client.get("items?upc_code=6523540947122")
+        response = self.client.get("items/search?upc_code=6523540947122")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            if item['Upc_Code'] != "6523540947122":
-                break
+            self.assertEqual(item['Upc_Code'] == "6523540947122")
     
     def test_search_items_by_model_number(self):
-        response = self.client.get("items?model_number=63-OFFTq0T")
+        response = self.client.get("items/search?model_number=63-OFFTq0T")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            if item['Model_Number'] != "63-OFFTq0T":
-                break
+            self.assertEqual(item['Model_Number'] == "63-OFFTq0T")
     
     def test_search_items_by_commodity_code(self):
-        response = self.client.get("items?commodity_code=oTo304")
+        response = self.client.get("items/search?commodity_code=oTo304")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            if item['Commodity_Code'] != "oTo304":
-                break
+            self.assertEqual(item['Commodity_Code'] == "oTo304")
     
     def test_search_items_by_supplier_code(self):
-        response = self.client.get("items?supplier_code=SUP423")
+        response = self.client.get("items/search?supplier_code=SUP423")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            if item['Supplier_Code'] != "SUP423":
-                break
+            self.assertEqual(item.supplier_code == "SUP423")
     
     def test_search_items_by_supplier_part_number(self):
-        response = self.client.get("items?supplier_part_number=E-86805-uTM")
+        response = self.client.get("items/search?supplier_part_number=E-86805-uTM")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            if item['Supplier_Part_Number'] != "E-86805-uTM":
-                break
+            self.assertEqual(item.supplier_part_number == "E-86805-uTM")
     
     def test_search_items_by_code_and_supplier_part_number(self):
-        response = self.client.get("items?code=sjQ23408K&supplier_part_number=E-86805-uTM")
+        response = self.client.get("items/search?code=sjQ23408K&supplier_part_number=E-86805-uTM")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            if item['Code'] != "sjQ23408K" or item['Supplier_Part_Number'] != "E-86805-uTM":
-                break
+            self.assertEqual(item.code == "sjQ23408K")
+            self.assertEqual(item.supplier_part_number == "E-86805-uTM")
     
     def test_search_items_by_description_and_upc_code(self):
-        response = self.client.get("items?description=Face-to-face clear-thinking complexity&upc_code=6523540947122")
+        response = self.client.get("items/search?description=Face-to-face clear-thinking complexity&upc_code=6523540947122")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            if item['Description'] != "Face-to-face clear-thinking complexity" or item['Upc_Code'] != "6523540947122":
-                break
+            self.assertEqual(item.description == "Face-to-face clear-thinking complexity")
+            self.assertEqual(item.upc_code == "6523540947122")
     
     def test_search_items_by_model_number_and_commodity_code(self):
-        response = self.client.get("items?model_number=63-OFFTq0T&commodity_code=oTo304")
+        response = self.client.get("items/search?model_number=63-OFFTq0T&commodity_code=oTo304")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            if item['Model_Number'] != "63-OFFTq0T" or item['Commodity_Code'] != "oTo304":
-                break
+            self.assertEqual(item['Model_Number'] == "63-OFFTq0T")
+            self.assertEqual(item['Commodity_Code'] == "oTo304")
+            
     # POST tests
     def test_4create_item(self):
         response = self.client.post("items", json=self.new_item)

--- a/C#api/Tests/test_locations.py
+++ b/C#api/Tests/test_locations.py
@@ -61,7 +61,7 @@ class ApiLocationsTests(unittest.TestCase):
                 break
     
     def test_search_locations_by_code(self):
-        response = self.client.get("locations?code=A.1.0")
+        response = self.client.get("locations/search?code=A.1.0")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for code in response.json():
@@ -69,7 +69,7 @@ class ApiLocationsTests(unittest.TestCase):
                 break
     
     def test_search_locations_by_warehouse_id(self):
-        response = self.client.get("locations?warehouse_id=1")
+        response = self.client.get("locations/search?warehouse_id=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for location in response.json():
@@ -77,7 +77,7 @@ class ApiLocationsTests(unittest.TestCase):
                 break
     
     def test_search_locations_by_name_and_code(self):
-        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0&code=A.1.0")
+        response = self.client.get("locations/search?name=Row: A, Rack: 1, Shelf: 0&code=A.1.0")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
@@ -85,7 +85,7 @@ class ApiLocationsTests(unittest.TestCase):
                 break
             
     def test_search_locations_by_name_and_warehouse_id(self):
-        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0&warehouse_id=1")
+        response = self.client.get("locations/search?name=Row: A, Rack: 1, Shelf: 0&warehouse_id=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
@@ -93,7 +93,7 @@ class ApiLocationsTests(unittest.TestCase):
                 break
             
     def test_search_locations_by_code_and_warehouse_id(self):
-        response = self.client.get("locations?code=A.1.0&warehouse_id=1")
+        response = self.client.get("locations/search?code=A.1.0&warehouse_id=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
@@ -101,7 +101,7 @@ class ApiLocationsTests(unittest.TestCase):
                 break
     
     def test_search_locations_by_name_and_code_and_warehouse_id(self):
-        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0&code=A.1.0&warehouse_id=1")
+        response = self.client.get("locations/search?name=Row: A, Rack: 1, Shelf: 0&code=A.1.0&warehouse_id=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():

--- a/C#api/Tests/test_locations.py
+++ b/C#api/Tests/test_locations.py
@@ -71,39 +71,50 @@ class ApiLocationsTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_search_locations_by_name(self):
-        response = self.client.get("locations?name=Location")
+        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Name'] == "Row: A, Rack: 1, Shelf: 0")
     
     def test_search_locations_by_code(self):
-        response = self.client.get("locations?code=LOC001")
+        response = self.client.get("locations?code=A.1.0")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Code'] == "A.1.0")
     
     def test_search_locations_by_warehouse_id(self):
         response = self.client.get("locations?warehouse_id=1")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Warehouse_Id'] == 1)
     
     def test_search_locations_by_name_and_code(self):
-        response = self.client.get("locations?name=Location&code=LOC001")
+        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0&code=A.1.0")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Name'] == "Row: A, Rack: 1, Shelf: 0")
+        self.assertTrue(response.json()[0]['Code'] == "A.1.0")
     
     def test_search_locations_by_name_and_warehouse_id(self):
-        response = self.client.get("locations?name=Location&warehouse_id=1")
+        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0&warehouse_id=1")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Name'] == "Row: A, Rack: 1, Shelf: 0")
+        self.assertTrue(response.json()[0]['Warehouse_Id'] == 1)
     
     def test_search_locations_by_code_and_warehouse_id(self):
-        response = self.client.get("locations?code=LOC001&warehouse_id=1")
+        response = self.client.get("locations?code=A.1.0&warehouse_id=1")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Code'] == "A.1.0")
     
     def test_search_locations_by_name_and_code_and_warehouse_id(self):
-        response = self.client.get("locations?name=Location&code=LOC001&warehouse_id=1")
+        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0&code=A.1.0&warehouse_id=1")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertTrue(response.json()[0]['Name'] == "Row: A, Rack: 1, Shelf: 0")
+        self.assertTrue(response.json()[0]['Code'] == "A.1.0")
+        self.assertTrue(response.json()[0]['Warehouse_Id'] == 1)
        
     # PUT tests
     def test_7update_existing_location(self):

--- a/C#api/Tests/test_locations.py
+++ b/C#api/Tests/test_locations.py
@@ -70,6 +70,41 @@ class ApiLocationsTests(unittest.TestCase):
         response = self.client.post("locations", json=duplicate_location)
         self.assertEqual(response.status_code, 404)
 
+    def test_search_locations_by_name(self):
+        response = self.client.get("locations?name=Location")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_locations_by_code(self):
+        response = self.client.get("locations?code=LOC001")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_locations_by_warehouse_id(self):
+        response = self.client.get("locations?warehouse_id=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_locations_by_name_and_code(self):
+        response = self.client.get("locations?name=Location&code=LOC001")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_locations_by_name_and_warehouse_id(self):
+        response = self.client.get("locations?name=Location&warehouse_id=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_locations_by_code_and_warehouse_id(self):
+        response = self.client.get("locations?code=LOC001&warehouse_id=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_locations_by_name_and_code_and_warehouse_id(self):
+        response = self.client.get("locations?name=Location&code=LOC001&warehouse_id=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+       
     # PUT tests
     def test_7update_existing_location(self):
         updated_location = {

--- a/C#api/Tests/test_locations.py
+++ b/C#api/Tests/test_locations.py
@@ -53,7 +53,7 @@ class ApiLocationsTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_search_locations_by_name(self):
-        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0")
+        response = self.client.get("locations/search?name=Row: A, Rack: 1, Shelf: 0")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for name in response.json():
@@ -90,7 +90,7 @@ class ApiLocationsTests(unittest.TestCase):
             self.assertEqual(x['Warehouse_Id'], 1)
             
     def test_search_locations_by_code_and_warehouse_id(self):
-        response = self.client.get("locations/search?code=A.1.0&warehouse_id=1")
+        response = self.client.get("locations/search?code=A.1.0&warehouseid=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
@@ -98,12 +98,14 @@ class ApiLocationsTests(unittest.TestCase):
             self.assertEqual(x['Warehouse_Id'], 1)
     
     def test_search_locations_by_name_and_code_and_warehouse_id(self):
-        response = self.client.get("locations/search?name=Row: A, Rack: 1, Shelf: 0&code=A.1.0&warehouse_id=1")
+        response = self.client.get("locations/search?name=Row: A, Rack: 1, Shelf: 0&code=A.1.0&warehouseid=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
             self.assertEqual(x['Name'], "Row: A, Rack: 1, Shelf: 0")
             self.assertEqual(x['Code'], "A.1.0")
+            self.assertEqual(x['Warehouse_Id'], 1)
+
        
     # POST tests
     def test_4create_location(self):

--- a/C#api/Tests/test_locations.py
+++ b/C#api/Tests/test_locations.py
@@ -52,6 +52,62 @@ class ApiLocationsTests(unittest.TestCase):
         response = self.client.get("locations/-1")
         self.assertEqual(response.status_code, 404)
 
+    def test_search_locations_by_name(self):
+        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        for name in response.json():
+            if name['Name'] != "Row: A, Rack: 1, Shelf: 0":
+                break
+    
+    def test_search_locations_by_code(self):
+        response = self.client.get("locations?code=A.1.0")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        for code in response.json():
+            if code['Code'] != "A.1.0":
+                break
+    
+    def test_search_locations_by_warehouse_id(self):
+        response = self.client.get("locations?warehouse_id=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        for location in response.json():
+            if location['Warehouse_Id'] != 1:
+                break
+    
+    def test_search_locations_by_name_and_code(self):
+        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0&code=A.1.0")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        for x in response.json():
+            if x['Name'] != "Row: A, Rack: 1, Shelf: 0" and x['Code'] != "A.1.0":
+                break
+            
+    def test_search_locations_by_name_and_warehouse_id(self):
+        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0&warehouse_id=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        for x in response.json():
+            if x['Name'] != "Row: A, Rack: 1, Shelf: 0" and x['Warehouse_Id'] != 1:
+                break
+            
+    def test_search_locations_by_code_and_warehouse_id(self):
+        response = self.client.get("locations?code=A.1.0&warehouse_id=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        for x in response.json():
+            if x['Code'] != "A.1.0" and x['Warehouse_Id'] != 1:
+                break
+    
+    def test_search_locations_by_name_and_code_and_warehouse_id(self):
+        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0&code=A.1.0&warehouse_id=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        for x in response.json():
+            if x['Name'] != "Row: A, Rack: 1, Shelf: 0" and x['Code'] != "A.1.0" and x['Warehouse_Id'] != 1:
+                break
+       
     # POST tests
     def test_4create_location(self):
         response = self.client.post("locations", json=self.new_location)
@@ -70,52 +126,6 @@ class ApiLocationsTests(unittest.TestCase):
         response = self.client.post("locations", json=duplicate_location)
         self.assertEqual(response.status_code, 404)
 
-    def test_search_locations_by_name(self):
-        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0")
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Name'] == "Row: A, Rack: 1, Shelf: 0")
-    
-    def test_search_locations_by_code(self):
-        response = self.client.get("locations?code=A.1.0")
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Code'] == "A.1.0")
-    
-    def test_search_locations_by_warehouse_id(self):
-        response = self.client.get("locations?warehouse_id=1")
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Warehouse_Id'] == 1)
-    
-    def test_search_locations_by_name_and_code(self):
-        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0&code=A.1.0")
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Name'] == "Row: A, Rack: 1, Shelf: 0")
-        self.assertTrue(response.json()[0]['Code'] == "A.1.0")
-    
-    def test_search_locations_by_name_and_warehouse_id(self):
-        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0&warehouse_id=1")
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Name'] == "Row: A, Rack: 1, Shelf: 0")
-        self.assertTrue(response.json()[0]['Warehouse_Id'] == 1)
-    
-    def test_search_locations_by_code_and_warehouse_id(self):
-        response = self.client.get("locations?code=A.1.0&warehouse_id=1")
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Code'] == "A.1.0")
-    
-    def test_search_locations_by_name_and_code_and_warehouse_id(self):
-        response = self.client.get("locations?name=Row: A, Rack: 1, Shelf: 0&code=A.1.0&warehouse_id=1")
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertTrue(response.json()[0]['Name'] == "Row: A, Rack: 1, Shelf: 0")
-        self.assertTrue(response.json()[0]['Code'] == "A.1.0")
-        self.assertTrue(response.json()[0]['Warehouse_Id'] == 1)
-       
     # PUT tests
     def test_7update_existing_location(self):
         updated_location = {

--- a/C#api/Tests/test_locations.py
+++ b/C#api/Tests/test_locations.py
@@ -57,56 +57,53 @@ class ApiLocationsTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for name in response.json():
-            if name['Name'] != "Row: A, Rack: 1, Shelf: 0":
-                break
+            self.assertEqual(name['Name'], "Row: A, Rack: 1, Shelf: 0")
     
     def test_search_locations_by_code(self):
         response = self.client.get("locations/search?code=A.1.0")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for code in response.json():
-            if code['Code'] != "A.1.0":
-                break
+            self.assertEqual(code['Code'], "A.1.0")
     
     def test_search_locations_by_warehouse_id(self):
         response = self.client.get("locations/search?warehouse_id=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for location in response.json():
-            if location['Warehouse_Id'] != 1:
-                break
+            self.assertTrue(location['Warehouse_Id'] == 1)
     
     def test_search_locations_by_name_and_code(self):
         response = self.client.get("locations/search?name=Row: A, Rack: 1, Shelf: 0&code=A.1.0")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            if x['Name'] != "Row: A, Rack: 1, Shelf: 0" and x['Code'] != "A.1.0":
-                break
+            self.assertEqual(x['Name'], "Row: A, Rack: 1, Shelf: 0")
+            self.assertEqual(x['Code'], "A.1.0")
             
     def test_search_locations_by_name_and_warehouse_id(self):
         response = self.client.get("locations/search?name=Row: A, Rack: 1, Shelf: 0&warehouse_id=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            if x['Name'] != "Row: A, Rack: 1, Shelf: 0" and x['Warehouse_Id'] != 1:
-                break
+            self.assertEqual(x['Name'], "Row: A, Rack: 1, Shelf: 0")
+            self.assertEqual(x['Warehouse_Id'], 1)
             
     def test_search_locations_by_code_and_warehouse_id(self):
         response = self.client.get("locations/search?code=A.1.0&warehouse_id=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            if x['Code'] != "A.1.0" and x['Warehouse_Id'] != 1:
-                break
+            self.assertEqual(x['Code'], "A.1.0")
+            self.assertEqual(x['Warehouse_Id'], 1)
     
     def test_search_locations_by_name_and_code_and_warehouse_id(self):
         response = self.client.get("locations/search?name=Row: A, Rack: 1, Shelf: 0&code=A.1.0&warehouse_id=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            if x['Name'] != "Row: A, Rack: 1, Shelf: 0" and x['Code'] != "A.1.0" and x['Warehouse_Id'] != 1:
-                break
+            self.assertEqual(x['Name'], "Row: A, Rack: 1, Shelf: 0")
+            self.assertEqual(x['Code'], "A.1.0")
        
     # POST tests
     def test_4create_location(self):

--- a/C#api/Tests/test_locations.py
+++ b/C#api/Tests/test_locations.py
@@ -67,7 +67,7 @@ class ApiLocationsTests(unittest.TestCase):
             self.assertEqual(code['Code'], "A.1.0")
     
     def test_search_locations_by_warehouse_id(self):
-        response = self.client.get("locations/search?warehouse_id=1")
+        response = self.client.get("locations/search?warehouseid=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for location in response.json():
@@ -82,7 +82,7 @@ class ApiLocationsTests(unittest.TestCase):
             self.assertEqual(x['Code'], "A.1.0")
             
     def test_search_locations_by_name_and_warehouse_id(self):
-        response = self.client.get("locations/search?name=Row: A, Rack: 1, Shelf: 0&warehouse_id=1")
+        response = self.client.get("locations/search?name=Row: A, Rack: 1, Shelf: 0&warehouseid=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():

--- a/C#api/Tests/test_orders.py
+++ b/C#api/Tests/test_orders.py
@@ -104,6 +104,22 @@ class ApiOrdersTests(unittest.TestCase):
         response = self.client.get("orders?shipment_id=4")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_orders_by_status_and_reference(self):
+        response = self.client.get("orders?status=Pending&reference=ORD123")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_orders_by_status_and_source_id(self):
+        response = self.client.get("orders?status=Pending&source_id=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_orders_by_status_and_warehouse_id(self):
+        response = self.client.get("orders?status=Pending&warehouse_id=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
 
     # POST tests
     def test_4create_order(self):

--- a/C#api/Tests/test_orders.py
+++ b/C#api/Tests/test_orders.py
@@ -69,6 +69,41 @@ class ApiOrdersTests(unittest.TestCase):
     def test_3get_non_existent_order(self):
         response = self.client.get("orders/-1")
         self.assertEqual(response.status_code, 404)
+    
+    def test_search_orders_by_reference(self):
+        response = self.client.get("orders?reference=ORD123")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_orders_by_status(self):
+        response = self.client.get("orders?status=Pending")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_orders_by_source_id(self):
+        response = self.client.get("orders?source_id=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_orders_by_warehouse_id(self):
+        response = self.client.get("orders?warehouse_id=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_orders_by_ship_to(self):
+        response = self.client.get("orders?ship_to=2")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_orders_by_bill_to(self):
+        response = self.client.get("orders?bill_to=3")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_orders_by_shipment_id(self):
+        response = self.client.get("orders?shipment_id=4")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
 
     # POST tests
     def test_4create_order(self):

--- a/C#api/Tests/test_orders.py
+++ b/C#api/Tests/test_orders.py
@@ -71,56 +71,68 @@ class ApiOrdersTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
     
     def test_search_orders_by_reference(self):
-        response = self.client.get("orders?reference=ORD123")
+        response = self.client.get("orders?reference=ORD00001")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Reference'], "ORD00001")
     
     def test_search_orders_by_status(self):
-        response = self.client.get("orders?status=Pending")
+        response = self.client.get("orders?status=Delivered")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Order_Status'], "Delivered")
     
     def test_search_orders_by_source_id(self):
-        response = self.client.get("orders?source_id=1")
+        response = self.client.get("orders?source_id=33")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Source_Id'], 33)
     
     def test_search_orders_by_warehouse_id(self):
-        response = self.client.get("orders?warehouse_id=1")
+        response = self.client.get("orders?warehouse_id=18")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Warehouse_Id'], 18)
     
     def test_search_orders_by_ship_to(self):
-        response = self.client.get("orders?ship_to=2")
+        response = self.client.get("orders?ship_to=4562")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Ship_To'], 4562)
     
     def test_search_orders_by_bill_to(self):
-        response = self.client.get("orders?bill_to=3")
+        response = self.client.get("orders?bill_to=7863")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Bill_To'], 7863)
     
     def test_search_orders_by_shipment_id(self):
-        response = self.client.get("orders?shipment_id=4")
+        response = self.client.get("orders?shipment_id=1")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Shipment_Id'], 1)
     
     def test_search_orders_by_status_and_reference(self):
-        response = self.client.get("orders?status=Pending&reference=ORD123")
+        response = self.client.get("orders?status=Delivered&reference=ORD00001")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
-    
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Order_Status'], "Delivered")
+        self.assertEqual(response.json()[0]['Reference'], "ORD00001")
+          
     def test_search_orders_by_status_and_source_id(self):
-        response = self.client.get("orders?status=Pending&source_id=1")
+        response = self.client.get("orders?status=Delivered&source_id=33")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Order_Status'], "Delivered")
+        self.assertEqual(response.json()[0]['Source_Id'], 33)
     
     def test_search_orders_by_status_and_warehouse_id(self):
-        response = self.client.get("orders?status=Pending&warehouse_id=1")
+        response = self.client.get("orders?status=Delivered&warehouse_id=18")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Order_Status'], "Delivered")
+        self.assertEqual(response.json()[0]['Warehouse_Id'], 18)
     
-
     # POST tests
     def test_4create_order(self):
         response = self.client.post("orders", json=self.new_order)

--- a/C#api/Tests/test_orders.py
+++ b/C#api/Tests/test_orders.py
@@ -71,7 +71,7 @@ class ApiOrdersTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
     
     def test_search_orders_by_reference(self):
-        response = self.client.get("orders?reference=ORD00001")
+        response = self.client.get("orders/search?reference=ORD00001")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for reference in response.json():
@@ -79,7 +79,7 @@ class ApiOrdersTests(unittest.TestCase):
                 break
     
     def test_search_orders_by_status(self):
-        response = self.client.get("orders?status=Delivered")
+        response = self.client.get("orders/search?status=Delivered")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for order in response.json():
@@ -87,7 +87,7 @@ class ApiOrdersTests(unittest.TestCase):
                 break
     
     def test_search_orders_by_source_id(self):
-        response = self.client.get("orders?source_id=33")
+        response = self.client.get("orders/search?source_id=33")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for order in response.json():
@@ -95,7 +95,7 @@ class ApiOrdersTests(unittest.TestCase):
                 break
             
     def test_search_orders_by_warehouse_id(self):
-        response = self.client.get("orders?warehouse_id=18")
+        response = self.client.get("orders/search?warehouse_id=18")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for order in response.json():
@@ -103,7 +103,7 @@ class ApiOrdersTests(unittest.TestCase):
                 break
     
     def test_search_orders_by_ship_to(self):
-        response = self.client.get("orders?ship_to=4562")
+        response = self.client.get("orders/search?ship_to=4562")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for order in response.json():
@@ -111,7 +111,7 @@ class ApiOrdersTests(unittest.TestCase):
                 break
     
     def test_search_orders_by_bill_to(self):
-        response = self.client.get("orders?bill_to=7863")
+        response = self.client.get("orders/search?bill_to=7863")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for order in response.json():
@@ -119,7 +119,7 @@ class ApiOrdersTests(unittest.TestCase):
                 break
     
     def test_search_orders_by_shipment_id(self):
-        response = self.client.get("orders?shipment_id=1")
+        response = self.client.get("orders/search?shipment_id=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for order in response.json():
@@ -127,7 +127,7 @@ class ApiOrdersTests(unittest.TestCase):
                 break
     
     def test_search_orders_by_status_and_reference(self):
-        response = self.client.get("orders?status=Delivered&reference=ORD00001")
+        response = self.client.get("orders/search?status=Delivered&reference=ORD00001")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for x in response.json():
@@ -135,7 +135,7 @@ class ApiOrdersTests(unittest.TestCase):
                 break
           
     def test_search_orders_by_status_and_source_id(self):
-        response = self.client.get("orders?status=Delivered&source_id=33")
+        response = self.client.get("orders/search?status=Delivered&source_id=33")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for x in response.json():
@@ -143,7 +143,7 @@ class ApiOrdersTests(unittest.TestCase):
                 break
             
     def test_search_orders_by_status_and_warehouse_id(self):
-        response = self.client.get("orders?status=Delivered&warehouse_id=18")
+        response = self.client.get("orders/search?status=Delivered&warehouse_id=18")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():

--- a/C#api/Tests/test_orders.py
+++ b/C#api/Tests/test_orders.py
@@ -75,45 +75,45 @@ class ApiOrdersTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for reference in response.json():
-            self.assertEqual(reference['Order_Reference'], "ORD00001")
+            self.assertEqual(reference['Reference'], "ORD00001")
     
     def test_search_orders_by_status(self):
-        response = self.client.get("orders/search?status=Delivered")
+        response = self.client.get("orders/search?orderstatus=Delivered")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for order in response.json():
             self.assertEqual(order['Order_Status'], "Delivered")
     
     def test_search_orders_by_source_id(self):
-        response = self.client.get("orders/search?source_id=33")
+        response = self.client.get("orders/search?sourceid=33")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for order in response.json():
             self.assertEqual(order['Source_Id'], 33)
             
     def test_search_orders_by_warehouse_id(self):
-        response = self.client.get("orders/search?warehouse_id=18")
+        response = self.client.get("orders/search?warehouseid=18")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for order in response.json():
             self.assertEqual(order['Warehouse_Id'], 18)
     
     def test_search_orders_by_ship_to(self):
-        response = self.client.get("orders/search?ship_to=4562")
+        response = self.client.get("orders/search?shipto=4562")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for order in response.json():
             self.assertEqual(order['Ship_To'], 4562)
     
     def test_search_orders_by_bill_to(self):
-        response = self.client.get("orders/search?bill_to=7863")
+        response = self.client.get("orders/search?billto=7863")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for order in response.json():
             self.assertEqual(order['Bill_To'], 7863)
     
     def test_search_orders_by_shipment_id(self):
-        response = self.client.get("orders/search?shipment_id=1")
+        response = self.client.get("orders/search?shipmentid=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for order in response.json():
@@ -128,7 +128,7 @@ class ApiOrdersTests(unittest.TestCase):
             self.assertEqual(x['Reference'], "ORD00001")
           
     def test_search_orders_by_status_and_source_id(self):
-        response = self.client.get("orders/search?status=Delivered&source_id=33")
+        response = self.client.get("orders/search?status=Delivered&sourceid=33")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
@@ -136,7 +136,7 @@ class ApiOrdersTests(unittest.TestCase):
             self.assertEqual(x['Source_Id'], 33)
             
     def test_search_orders_by_status_and_warehouse_id(self):
-        response = self.client.get("orders/search?status=Delivered&warehouse_id=18")
+        response = self.client.get("orders/search?status=Delivered&warehouseid=18")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():

--- a/C#api/Tests/test_orders.py
+++ b/C#api/Tests/test_orders.py
@@ -74,65 +74,82 @@ class ApiOrdersTests(unittest.TestCase):
         response = self.client.get("orders?reference=ORD00001")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Reference'], "ORD00001")
+        for reference in response.json():
+            if reference['Reference'] != "ORD00001":
+                break
     
     def test_search_orders_by_status(self):
         response = self.client.get("orders?status=Delivered")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Order_Status'], "Delivered")
+        for order in response.json():
+            if order['Order_Status'] != "Delivered":
+                break
     
     def test_search_orders_by_source_id(self):
         response = self.client.get("orders?source_id=33")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Source_Id'], 33)
-    
+        for order in response.json():
+            if order['Source_Id'] != 33:
+                break
+            
     def test_search_orders_by_warehouse_id(self):
         response = self.client.get("orders?warehouse_id=18")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Warehouse_Id'], 18)
+        for order in response.json():
+            if order['Warehouse_Id'] != 18:
+                break
     
     def test_search_orders_by_ship_to(self):
         response = self.client.get("orders?ship_to=4562")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Ship_To'], 4562)
+        for order in response.json():
+            if order['Ship_To'] != 4562:
+                break
     
     def test_search_orders_by_bill_to(self):
         response = self.client.get("orders?bill_to=7863")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Bill_To'], 7863)
+        for order in response.json():
+            if order['Bill_To'] != 7863:
+                break
     
     def test_search_orders_by_shipment_id(self):
         response = self.client.get("orders?shipment_id=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Shipment_Id'], 1)
+        for order in response.json():
+            if order['Shipment_Id'] != 1:
+                break
     
     def test_search_orders_by_status_and_reference(self):
         response = self.client.get("orders?status=Delivered&reference=ORD00001")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Order_Status'], "Delivered")
-        self.assertEqual(response.json()[0]['Reference'], "ORD00001")
+        for x in response.json():
+            if x['Order_Status'] != "Delivered" and x['Order_Reference'] != "ORD00001":
+                break
           
     def test_search_orders_by_status_and_source_id(self):
         response = self.client.get("orders?status=Delivered&source_id=33")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Order_Status'], "Delivered")
-        self.assertEqual(response.json()[0]['Source_Id'], 33)
-    
+        for x in response.json():
+            if x['Order_Status'] != "Delivered" and x['Source_Id'] != 33:
+                break
+            
     def test_search_orders_by_status_and_warehouse_id(self):
         response = self.client.get("orders?status=Delivered&warehouse_id=18")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Order_Status'], "Delivered")
-        self.assertEqual(response.json()[0]['Warehouse_Id'], 18)
-    
+        for x in response.json():
+            if x['Order_Status'] != "Delivered" and x['Warehouse_Id'] != 18:
+                break
+            
     # POST tests
     def test_4create_order(self):
         response = self.client.post("orders", json=self.new_order)

--- a/C#api/Tests/test_orders.py
+++ b/C#api/Tests/test_orders.py
@@ -73,82 +73,75 @@ class ApiOrdersTests(unittest.TestCase):
     def test_search_orders_by_reference(self):
         response = self.client.get("orders/search?reference=ORD00001")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for reference in response.json():
-            if reference['Reference'] != "ORD00001":
-                break
+            self.assertEqual(reference['Order_Reference'], "ORD00001")
     
     def test_search_orders_by_status(self):
         response = self.client.get("orders/search?status=Delivered")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for order in response.json():
-            if order['Order_Status'] != "Delivered":
-                break
+            self.assertEqual(order['Order_Status'], "Delivered")
     
     def test_search_orders_by_source_id(self):
         response = self.client.get("orders/search?source_id=33")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for order in response.json():
-            if order['Source_Id'] != 33:
-                break
+            self.assertEqual(order['Source_Id'], 33)
             
     def test_search_orders_by_warehouse_id(self):
         response = self.client.get("orders/search?warehouse_id=18")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for order in response.json():
-            if order['Warehouse_Id'] != 18:
-                break
+            self.assertEqual(order['Warehouse_Id'], 18)
     
     def test_search_orders_by_ship_to(self):
         response = self.client.get("orders/search?ship_to=4562")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for order in response.json():
-            if order['Ship_To'] != 4562:
-                break
+            self.assertEqual(order['Ship_To'], 4562)
     
     def test_search_orders_by_bill_to(self):
         response = self.client.get("orders/search?bill_to=7863")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for order in response.json():
-            if order['Bill_To'] != 7863:
-                break
+            self.assertEqual(order['Bill_To'], 7863)
     
     def test_search_orders_by_shipment_id(self):
         response = self.client.get("orders/search?shipment_id=1")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for order in response.json():
-            if order['Shipment_Id'] != 1:
-                break
+            self.assertEqual(order['Shipment_Id'], 1)
     
     def test_search_orders_by_status_and_reference(self):
         response = self.client.get("orders/search?status=Delivered&reference=ORD00001")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.status_code)
         for x in response.json():
-            if x['Order_Status'] != "Delivered" and x['Order_Reference'] != "ORD00001":
-                break
+            self.assertEqual(x['Order_Status'], "Delivered")
+            self.assertEqual(x['Reference'], "ORD00001")
           
     def test_search_orders_by_status_and_source_id(self):
         response = self.client.get("orders/search?status=Delivered&source_id=33")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            if x['Order_Status'] != "Delivered" and x['Source_Id'] != 33:
-                break
+            self.assertEqual(x['Order_Status'], "Delivered")
+            self.assertEqual(x['Source_Id'], 33)
             
     def test_search_orders_by_status_and_warehouse_id(self):
         response = self.client.get("orders/search?status=Delivered&warehouse_id=18")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            if x['Order_Status'] != "Delivered" and x['Warehouse_Id'] != 18:
-                break
+            self.assertEqual(x['Order_Status'], "Delivered")
+            self.assertEqual(x['Warehouse_Id'], 18)
             
     # POST tests
     def test_4create_order(self):

--- a/C#api/Tests/test_shipments.py
+++ b/C#api/Tests/test_shipments.py
@@ -79,37 +79,46 @@ class ApiShipmentsTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
     
     def test_search_shipments_by_order_id(self):
-        response = self.client.get("shipments?order_id=123")
+        response = self.client.get("shipments?order_id=1")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Order_Id'], 1)
+        
     def test_search_shipments_by_shipment_status(self):
         response = self.client.get("shipments?shipment_status=Pending")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Shipment_Status'], "Pending")
+        
     def test_search_shipments_by_shipment_date(self):
-        response = self.client.get("shipments?shipment_date=2022-01-01")
+        response = self.client.get("shipments?shipment_date=2000-03-13")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Shipment_Date'], "2000-03-13")
     
     def test_search_shipments_by_request_date(self):
-        response = self.client.get("shipments?request_date=2022-01-01")
+        response = self.client.get("shipments?request_date=2000-03-11")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Request_Date'], "2000-03-11")
     
     def test_search_shipments_by_carrier_code(self):
-        response = self.client.get("shipments?carrier_code=UPS")
+        response = self.client.get("shipments?carrier_code=DPD")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Carrier_Code'], "DPD")
     
     def test_search_shipments_by_source_id(self):
-        response = self.client.get("shipments?source_id=1")
+        response = self.client.get("shipments?source_id=33")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Source_Id'], 33)
     
     def test_search_shipments_by_order_id_and_shipment_status(self):
-        response = self.client.get("shipments?order_id=123&shipment_status=Pending")
+        response = self.client.get("shipments?order_id=1&shipment_status=Pending")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Order_Id'], 1, "Pending")
 
     # POST tests
     def test_4create_shipment(self):

--- a/C#api/Tests/test_shipments.py
+++ b/C#api/Tests/test_shipments.py
@@ -105,6 +105,11 @@ class ApiShipmentsTests(unittest.TestCase):
         response = self.client.get("shipments?source_id=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_shipments_by_order_id_and_shipment_status(self):
+        response = self.client.get("shipments?order_id=123&shipment_status=Pending")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
 
     # POST tests
     def test_4create_shipment(self):

--- a/C#api/Tests/test_shipments.py
+++ b/C#api/Tests/test_shipments.py
@@ -83,56 +83,50 @@ class ApiShipmentsTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            if item['Order_Id'] != 1:
-                break
+            self.assertEqual(item['Order_Id'], 1)
         
     def test_search_shipments_by_shipment_status(self):
         response = self.client.get("shipments/search?shipment_status=Pending")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for status in response.json():
-            if status['Shipment_Status'] != "Pending":
-                break
+            self.assertEqual(status['Shipment_Status'], "Pending")
         
     def test_search_shipments_by_shipment_date(self):
         response = self.client.get("shipments/search?shipment_date=2000-03-13")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for date in response.json():
-            if date['Shipment_Date'] != "2000-03-13":
-                break
+            self.assertEqual(date['Shipment_Date'], "2000-03-13")
     
     def test_search_shipments_by_request_date(self):
         response = self.client.get("shipments/search?request_date=2000-03-11")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for date in response.json():
-            if date['Request_Date'] != "2000-03-11":
-                break
+            self.assertEqual(date['Request_Date'], "2000-03-11")
     
     def test_search_shipments_by_carrier_code(self):
         response = self.client.get("shipments/search?carrier_code=DPD")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for shipment in response.json():
-            if shipment['Carrier_Code'] != "DPD":
-                break
+            self.assertEqual(shipment['Carrier_Code'], "DPD")
     
     def test_search_shipments_by_source_id(self):
         response = self.client.get("shipments/search?source_id=33")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for shipment in response.json():
-            if shipment['Source_Id'] != 33:
-                break
+            self.assertEqual(shipment['Source_Id'], 33)
     
     def test_search_shipments_by_order_id_and_shipment_status(self):
         response = self.client.get("shipments/search?order_id=1&shipment_status=Pending")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            if x['Order_Id'] != 1 or x['Shipment_Status'] != "Pending":
-                break
+            self.assertEqual(x['Order_Id'], 1)
+            self.assertEqual(x['Shipment_Status'], "Pending")
 
     # POST tests
     def test_4create_shipment(self):

--- a/C#api/Tests/test_shipments.py
+++ b/C#api/Tests/test_shipments.py
@@ -79,49 +79,49 @@ class ApiShipmentsTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
     
     def test_search_shipments_by_order_id(self):
-        response = self.client.get("shipments/search?order_id=1")
+        response = self.client.get("shipments/search?orderid=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
             self.assertEqual(item['Order_Id'], 1)
         
     def test_search_shipments_by_shipment_status(self):
-        response = self.client.get("shipments/search?shipment_status=Pending")
+        response = self.client.get("shipments/search?shipmentstatus=Pending")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for status in response.json():
             self.assertEqual(status['Shipment_Status'], "Pending")
         
     def test_search_shipments_by_shipment_date(self):
-        response = self.client.get("shipments/search?shipment_date=2000-03-13")
+        response = self.client.get("shipments/search?shipmentdate=2000-03-13")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for date in response.json():
             self.assertEqual(date['Shipment_Date'], "2000-03-13")
     
     def test_search_shipments_by_request_date(self):
-        response = self.client.get("shipments/search?request_date=2000-03-11")
+        response = self.client.get("shipments/search?requestdate=2000-03-11")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for date in response.json():
             self.assertEqual(date['Request_Date'], "2000-03-11")
     
     def test_search_shipments_by_carrier_code(self):
-        response = self.client.get("shipments/search?carrier_code=DPD")
+        response = self.client.get("shipments/search?carriercode=DPD")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for shipment in response.json():
             self.assertEqual(shipment['Carrier_Code'], "DPD")
     
     def test_search_shipments_by_source_id(self):
-        response = self.client.get("shipments/search?source_id=33")
+        response = self.client.get("shipments/search?sourceid=33")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for shipment in response.json():
             self.assertEqual(shipment['Source_Id'], 33)
     
     def test_search_shipments_by_order_id_and_shipment_status(self):
-        response = self.client.get("shipments/search?order_id=1&shipment_status=Pending")
+        response = self.client.get("shipments/search?orderid=1&shipmentstatus=Pending")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():

--- a/C#api/Tests/test_shipments.py
+++ b/C#api/Tests/test_shipments.py
@@ -79,7 +79,7 @@ class ApiShipmentsTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
     
     def test_search_shipments_by_order_id(self):
-        response = self.client.get("shipments?order_id=1")
+        response = self.client.get("shipments/search?order_id=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
@@ -87,7 +87,7 @@ class ApiShipmentsTests(unittest.TestCase):
                 break
         
     def test_search_shipments_by_shipment_status(self):
-        response = self.client.get("shipments?shipment_status=Pending")
+        response = self.client.get("shipments/search?shipment_status=Pending")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for status in response.json():
@@ -95,7 +95,7 @@ class ApiShipmentsTests(unittest.TestCase):
                 break
         
     def test_search_shipments_by_shipment_date(self):
-        response = self.client.get("shipments?shipment_date=2000-03-13")
+        response = self.client.get("shipments/search?shipment_date=2000-03-13")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for date in response.json():
@@ -103,7 +103,7 @@ class ApiShipmentsTests(unittest.TestCase):
                 break
     
     def test_search_shipments_by_request_date(self):
-        response = self.client.get("shipments?request_date=2000-03-11")
+        response = self.client.get("shipments/search?request_date=2000-03-11")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for date in response.json():
@@ -111,7 +111,7 @@ class ApiShipmentsTests(unittest.TestCase):
                 break
     
     def test_search_shipments_by_carrier_code(self):
-        response = self.client.get("shipments?carrier_code=DPD")
+        response = self.client.get("shipments/search?carrier_code=DPD")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for shipment in response.json():
@@ -119,7 +119,7 @@ class ApiShipmentsTests(unittest.TestCase):
                 break
     
     def test_search_shipments_by_source_id(self):
-        response = self.client.get("shipments?source_id=33")
+        response = self.client.get("shipments/search?source_id=33")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for shipment in response.json():
@@ -127,7 +127,7 @@ class ApiShipmentsTests(unittest.TestCase):
                 break
     
     def test_search_shipments_by_order_id_and_shipment_status(self):
-        response = self.client.get("shipments?order_id=1&shipment_status=Pending")
+        response = self.client.get("shipments/search?order_id=1&shipment_status=Pending")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():

--- a/C#api/Tests/test_shipments.py
+++ b/C#api/Tests/test_shipments.py
@@ -82,43 +82,57 @@ class ApiShipmentsTests(unittest.TestCase):
         response = self.client.get("shipments?order_id=1")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Order_Id'], 1)
+        for item in response.json():
+            if item['Order_Id'] != 1:
+                break
         
     def test_search_shipments_by_shipment_status(self):
         response = self.client.get("shipments?shipment_status=Pending")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Shipment_Status'], "Pending")
+        for status in response.json():
+            if status['Shipment_Status'] != "Pending":
+                break
         
     def test_search_shipments_by_shipment_date(self):
         response = self.client.get("shipments?shipment_date=2000-03-13")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Shipment_Date'], "2000-03-13")
+        for date in response.json():
+            if date['Shipment_Date'] != "2000-03-13":
+                break
     
     def test_search_shipments_by_request_date(self):
         response = self.client.get("shipments?request_date=2000-03-11")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Request_Date'], "2000-03-11")
+        for date in response.json():
+            if date['Request_Date'] != "2000-03-11":
+                break
     
     def test_search_shipments_by_carrier_code(self):
         response = self.client.get("shipments?carrier_code=DPD")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Carrier_Code'], "DPD")
+        for shipment in response.json():
+            if shipment['Carrier_Code'] != "DPD":
+                break
     
     def test_search_shipments_by_source_id(self):
         response = self.client.get("shipments?source_id=33")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Source_Id'], 33)
+        for shipment in response.json():
+            if shipment['Source_Id'] != 33:
+                break
     
     def test_search_shipments_by_order_id_and_shipment_status(self):
         response = self.client.get("shipments?order_id=1&shipment_status=Pending")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Order_Id'], 1, "Pending")
+        for x in response.json():
+            if x['Order_Id'] != 1 or x['Shipment_Status'] != "Pending":
+                break
 
     # POST tests
     def test_4create_shipment(self):

--- a/C#api/Tests/test_shipments.py
+++ b/C#api/Tests/test_shipments.py
@@ -77,6 +77,34 @@ class ApiShipmentsTests(unittest.TestCase):
     def test_3get_non_existent_shipment(self):
         response = self.client.get("shipments/-1")
         self.assertEqual(response.status_code, 404)
+    
+    def test_search_shipments_by_order_id(self):
+        response = self.client.get("shipments?order_id=123")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    def test_search_shipments_by_shipment_status(self):
+        response = self.client.get("shipments?shipment_status=Pending")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    def test_search_shipments_by_shipment_date(self):
+        response = self.client.get("shipments?shipment_date=2022-01-01")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_shipments_by_request_date(self):
+        response = self.client.get("shipments?request_date=2022-01-01")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_shipments_by_carrier_code(self):
+        response = self.client.get("shipments?carrier_code=UPS")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_shipments_by_source_id(self):
+        response = self.client.get("shipments?source_id=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
 
     # POST tests
     def test_4create_shipment(self):

--- a/C#api/Tests/test_suppliers.py
+++ b/C#api/Tests/test_suppliers.py
@@ -64,49 +64,65 @@ class ApiSuppliersTests(unittest.TestCase):
         response = self.client.get(f"suppliers?name=Lee, Parks and Johnson")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Name'], "Lee, Parks and Johnson")
+        for name in response.json():
+            if name['Name'] != "Lee, Parks and Johnson":
+                break
         
     def test_search_suppliers_city(self):
         response = self.client.get(f"suppliers?city=Port Anitaburgh")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['City'], "Port Anitaburgh")
+        for city in response.json():
+            if city['City'] != "Port Anitaburgh":
+                break
     
     def test_search_suppliers_country(self):
         response = self.client.get(f"suppliers?country=Czech Republic")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Country'], "Czech Republic")
+        for country in response.json():
+            if country['Country'] != "Czech Republic":
+                break
     
     def test_search_suppliers_code(self):
         response = self.client.get(f"suppliers?code=SUP0001")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Code'], "SUP0001")
+        for code in response.json():
+            if code['Code'] != "SUP0001":
+                break
     
     def test_search_suppliers_reference(self):
         response = self.client.get(f"suppliers?reference=LPaJ-SUP0001")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Reference'], "LPaJ-SUP0001")
+        for reference in response.json():
+            if reference['Reference'] != "LPaJ-SUP0001":
+                break
         
     def test_search_suppliers_reference_and_name(self):
         response = self.client.get(f"suppliers?reference=LPaJ-SUP0001&name=Lee, Parks and Johnson")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Reference'], "LPaJ-SUP0001", "Lee, Parks and Johnson")
+        for name, value in response.json():
+            if name['Reference'] != "LPaJ-SUP0001" and name['Name'] != "Lee, Parks and Johnson":
+                break
     
     def test_search_suppliers_reference_and_city(self):
         response = self.client.get(f"suppliers?reference=LPaJ-SUP0001&city=Port Anitaburgh")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Reference'], "LPaJ-SUP0001", "Port Anitaburgh")
+        for city in response.json():
+            if city['Reference'] != "LPaJ-SUP0001" and city['City'] != "Port Anitaburgh":
+                break
     
     def test_search_suppliers_reference_and_country(self):
         response = self.client.get(f"suppliers?reference=LPaJ-SUP0001&country=Czech Republic")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        self.assertEqual(response.json()[0]['Reference'], "LPaJ-SUP0001", "Czech Republic")
+        for country in response.json():
+            if country['Reference'] != "LPaJ-SUP0001" and country['Country'] != "Czech Republic":
+                break
 
     # POST tests
 

--- a/C#api/Tests/test_suppliers.py
+++ b/C#api/Tests/test_suppliers.py
@@ -65,64 +65,59 @@ class ApiSuppliersTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for name in response.json():
-            if name['Name'] != "Lee, Parks and Johnson":
-                break
+            self.assertEqual(name['Name'], "Lee, Parks and Johnson")
         
     def test_search_suppliers_city(self):
         response = self.client.get(f"suppliers/search?city=Port Anitaburgh")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for city in response.json():
-            if city['City'] != "Port Anitaburgh":
-                break
+            self.assertEqual(city['City'], "Port Anitaburgh")
     
     def test_search_suppliers_country(self):
         response = self.client.get(f"suppliers/search?country=Czech Republic")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for country in response.json():
-            if country['Country'] != "Czech Republic":
-                break
+            self.assertEqual(country['Country'], "Czech Republic")
     
     def test_search_suppliers_code(self):
         response = self.client.get(f"suppliers/search?code=SUP0001")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for code in response.json():
-            if code['Code'] != "SUP0001":
-                break
+            self.assertEqual(code['Code'], "SUP0001")
     
     def test_search_suppliers_reference(self):
         response = self.client.get(f"suppliers/search?reference=LPaJ-SUP0001")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for reference in response.json():
-            if reference['Reference'] != "LPaJ-SUP0001":
-                break
+            self.assertEqual(reference['Reference'], "LPaJ-SUP0001")
         
     def test_search_suppliers_reference_and_name(self):
         response = self.client.get(f"suppliers/search?reference=LPaJ-SUP0001&name=Lee, Parks and Johnson")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for name in response.json():
-            if name['Reference'] != "LPaJ-SUP0001" and name['Name'] != "Lee, Parks and Johnson":
-                break
+            self.assertEqual(name['Reference'], "LPaJ-SUP0001")
+            self.assertEqual(name['Name'], "Lee, Parks and Johnson")
     
     def test_search_suppliers_reference_and_city(self):
         response = self.client.get(f"suppliers/search?reference=LPaJ-SUP0001&city=Port Anitaburgh")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for city in response.json():
-            if city['Reference'] != "LPaJ-SUP0001" and city['City'] != "Port Anitaburgh":
-                break
+            self.assertEqual(city['Reference'], "LPaJ-SUP0001")
+            self.assertEqual(city['City'], "Port Anitaburgh")
     
     def test_search_suppliers_reference_and_country(self):
         response = self.client.get(f"suppliers/search?reference=LPaJ-SUP0001&country=Czech Republic")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for country in response.json():
-            if country['Reference'] != "LPaJ-SUP0001" and country['Country'] != "Czech Republic":
-                break
+            self.assertEqual(country['Reference'], "LPaJ-SUP0001")
+            self.assertEqual(country['Country'], "Czech Republic")
 
     # POST tests
 

--- a/C#api/Tests/test_suppliers.py
+++ b/C#api/Tests/test_suppliers.py
@@ -59,6 +59,31 @@ class ApiSuppliersTests(unittest.TestCase):
     def test_3get_non_existent_supplier(self):
         response = self.client.get("suppliers/-1")
         self.assertEqual(response.status_code, 404)
+    
+    def test_search_suppliers_name(self):
+        response = self.client.get(f"suppliers?name=Supplier")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+        
+    def test_search_suppliers_city(self):
+        response = self.client.get(f"suppliers?city=Supplier City")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_suppliers_country(self):
+        response = self.client.get(f"suppliers?country=Supplierland")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_suppliers_code(self):
+        response = self.client.get(f"suppliers?code=SUP001")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_suppliers_reference(self):
+        response = self.client.get(f"suppliers?reference=REF001")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
 
     # POST tests
 

--- a/C#api/Tests/test_suppliers.py
+++ b/C#api/Tests/test_suppliers.py
@@ -61,44 +61,52 @@ class ApiSuppliersTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
     
     def test_search_suppliers_name(self):
-        response = self.client.get(f"suppliers?name=Supplier")
+        response = self.client.get(f"suppliers?name=Lee, Parks and Johnson")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Name'], "Lee, Parks and Johnson")
         
     def test_search_suppliers_city(self):
-        response = self.client.get(f"suppliers?city=Supplier City")
+        response = self.client.get(f"suppliers?city=Port Anitaburgh")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['City'], "Port Anitaburgh")
     
     def test_search_suppliers_country(self):
-        response = self.client.get(f"suppliers?country=Supplierland")
+        response = self.client.get(f"suppliers?country=Czech Republic")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Country'], "Czech Republic")
     
     def test_search_suppliers_code(self):
-        response = self.client.get(f"suppliers?code=SUP001")
+        response = self.client.get(f"suppliers?code=SUP0001")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Code'], "SUP0001")
     
     def test_search_suppliers_reference(self):
-        response = self.client.get(f"suppliers?reference=REF001")
+        response = self.client.get(f"suppliers?reference=LPaJ-SUP0001")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Reference'], "LPaJ-SUP0001")
         
     def test_search_suppliers_reference_and_name(self):
-        response = self.client.get(f"suppliers?reference=REF001&name=New Supplier")
+        response = self.client.get(f"suppliers?reference=LPaJ-SUP0001&name=Lee, Parks and Johnson")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Reference'], "LPaJ-SUP0001", "Lee, Parks and Johnson")
     
     def test_search_suppliers_reference_and_city(self):
-        response = self.client.get(f"suppliers?reference=REF001&city=Supplier City")
+        response = self.client.get(f"suppliers?reference=LPaJ-SUP0001&city=Port Anitaburgh")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Reference'], "LPaJ-SUP0001", "Port Anitaburgh")
     
     def test_search_suppliers_reference_and_country(self):
-        response = self.client.get(f"suppliers?reference=REF001&country=Supplierland")
+        response = self.client.get(f"suppliers?reference=LPaJ-SUP0001&country=Czech Republic")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, response.json())
+        self.assertEqual(response.json()[0]['Reference'], "LPaJ-SUP0001", "Czech Republic")
 
     # POST tests
 

--- a/C#api/Tests/test_suppliers.py
+++ b/C#api/Tests/test_suppliers.py
@@ -84,6 +84,21 @@ class ApiSuppliersTests(unittest.TestCase):
         response = self.client.get(f"suppliers?reference=REF001")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0)
+        
+    def test_search_suppliers_reference_and_name(self):
+        response = self.client.get(f"suppliers?reference=REF001&name=New Supplier")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_suppliers_reference_and_city(self):
+        response = self.client.get(f"suppliers?reference=REF001&city=Supplier City")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_suppliers_reference_and_country(self):
+        response = self.client.get(f"suppliers?reference=REF001&country=Supplierland")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
 
     # POST tests
 

--- a/C#api/Tests/test_suppliers.py
+++ b/C#api/Tests/test_suppliers.py
@@ -61,7 +61,7 @@ class ApiSuppliersTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
     
     def test_search_suppliers_name(self):
-        response = self.client.get(f"suppliers?name=Lee, Parks and Johnson")
+        response = self.client.get(f"suppliers/search?name=Lee, Parks and Johnson")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for name in response.json():
@@ -69,7 +69,7 @@ class ApiSuppliersTests(unittest.TestCase):
                 break
         
     def test_search_suppliers_city(self):
-        response = self.client.get(f"suppliers?city=Port Anitaburgh")
+        response = self.client.get(f"suppliers/search?city=Port Anitaburgh")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for city in response.json():
@@ -77,7 +77,7 @@ class ApiSuppliersTests(unittest.TestCase):
                 break
     
     def test_search_suppliers_country(self):
-        response = self.client.get(f"suppliers?country=Czech Republic")
+        response = self.client.get(f"suppliers/search?country=Czech Republic")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for country in response.json():
@@ -85,7 +85,7 @@ class ApiSuppliersTests(unittest.TestCase):
                 break
     
     def test_search_suppliers_code(self):
-        response = self.client.get(f"suppliers?code=SUP0001")
+        response = self.client.get(f"suppliers/search?code=SUP0001")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for code in response.json():
@@ -93,7 +93,7 @@ class ApiSuppliersTests(unittest.TestCase):
                 break
     
     def test_search_suppliers_reference(self):
-        response = self.client.get(f"suppliers?reference=LPaJ-SUP0001")
+        response = self.client.get(f"suppliers/search?reference=LPaJ-SUP0001")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for reference in response.json():
@@ -101,15 +101,15 @@ class ApiSuppliersTests(unittest.TestCase):
                 break
         
     def test_search_suppliers_reference_and_name(self):
-        response = self.client.get(f"suppliers?reference=LPaJ-SUP0001&name=Lee, Parks and Johnson")
+        response = self.client.get(f"suppliers/search?reference=LPaJ-SUP0001&name=Lee, Parks and Johnson")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        for name, value in response.json():
+        for name in response.json():
             if name['Reference'] != "LPaJ-SUP0001" and name['Name'] != "Lee, Parks and Johnson":
                 break
     
     def test_search_suppliers_reference_and_city(self):
-        response = self.client.get(f"suppliers?reference=LPaJ-SUP0001&city=Port Anitaburgh")
+        response = self.client.get(f"suppliers/search?reference=LPaJ-SUP0001&city=Port Anitaburgh")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for city in response.json():
@@ -117,7 +117,7 @@ class ApiSuppliersTests(unittest.TestCase):
                 break
     
     def test_search_suppliers_reference_and_country(self):
-        response = self.client.get(f"suppliers?reference=LPaJ-SUP0001&country=Czech Republic")
+        response = self.client.get(f"suppliers/search?reference=LPaJ-SUP0001&country=Czech Republic")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for country in response.json():

--- a/C#api/Tests/test_transfers.py
+++ b/C#api/Tests/test_transfers.py
@@ -60,6 +60,32 @@ class ApiTransfersTests(unittest.TestCase):
     def test_3get_non_existent_transfer(self):
         response = self.client.get("transfers/-1")
         self.assertEqual(response.status_code, 404)
+    
+    def test_search_transfers_reference(self):
+        response = self.client.get("transfers?reference=TRANS123")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+        self.assertEqual(response.json()[0]['Reference'], "TRANS123")
+    
+    def test_search_transfers_transfer_from(self):
+        response = self.client.get("transfers?transfer_from=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_transfers_transfer_to(self):
+        response = self.client.get("transfers?transfer_to=2")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_transfers_transfer_status(self):
+        response = self.client.get("transfers?transfer_status=Scheduled")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_transfers_created_at(self):
+        response = self.client.get("transfers?created_at=2024-11-14T16:10:14.227318")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
 
     # POST tests
     def test_4create_transfer(self):

--- a/C#api/Tests/test_transfers.py
+++ b/C#api/Tests/test_transfers.py
@@ -65,49 +65,65 @@ class ApiTransfersTests(unittest.TestCase):
         response = self.client.get("transfers?reference=TR00001")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json())> 0, True)
-        self.assertEqual(response.json()[0]['Reference'], "TR00001")
+        for reference in response.json():
+            if reference['Reference'] != "TR00001":
+                break
     
     def test_search_transfers_transfer_from(self):
         response = self.client.get("transfers?transfer_from=None")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Transfer_From'], None)
+        for transfer in response.json():
+            if transfer['Transfer_From'] != None:
+                break
     
     def test_search_transfers_transfer_to(self):
         response = self.client.get("transfers?transfer_to=9229")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Transfer_To'], 9229)
+        for transfer in response.json():
+            if transfer['Transfer_To'] != 9229:
+                break
     
     def test_search_transfers_transfer_status(self):
         response = self.client.get("transfers?transfer_status=Completed")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Transfer_Status'], "Completed")
-    
+        for transfer in response.json():
+            if transfer['Transfer_Status'] != "Completed":
+                break
+            
     def test_search_transfers_created_at(self):
         response = self.client.get("transfers?created_at=2000-03-11T13:11:14Z")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Created_At'], "2000-03-11T13:11:14Z")
+        for transfer in response.json():
+            if transfer['Created_At'] != "2000-03-11T13:11:14Z":
+                break
     
     def test_search_transfers_reference_and_transfer_status(self):
         response = self.client.get("transfers?reference=TR00001&transfer_status=Completed")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Reference'], "TR00001", "Completed")
+        for x in response.json():
+            if x['Reference']!= "TR00001" and x['Transfer_Status']!= "Completed":
+                break
     
     def test_search_transfers_reference_and_transfer_from(self):
         response = self.client.get("transfers?reference=TR00001&transfer_from=None")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Reference'], "TR00001", "None")
+        for x in response.json():
+            if x['Reference']!= "TR00001" and x['Transfer_From']!= None:
+                break
     
     def test_search_transfers_reference_and_transfer_to(self):
         response = self.client.get("transfers?reference=TR00001&transfer_to=2")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Reference'], "TR00001", 9229)
+        for x in response.json():
+            if x['Reference']!= "TR00001" and x['Transfer_To']!= 2:
+                break
 
     # POST tests
     def test_4create_transfer(self):

--- a/C#api/Tests/test_transfers.py
+++ b/C#api/Tests/test_transfers.py
@@ -64,66 +64,61 @@ class ApiTransfersTests(unittest.TestCase):
     def test_search_transfers_reference(self):
         response = self.client.get("transfers/search?reference=TR00001")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json())> 0, True)
+        self.assertEqual(len(response.json())> 0, response.json())
         for reference in response.json():
-            if reference['Reference'] != "TR00001":
-                break
+            self.assertEqual(reference['reference'], "TR00001")
     
     def test_search_transfers_transfer_from(self):
         response = self.client.get("transfers/search?transfer_from=None")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for transfer in response.json():
-            if transfer['Transfer_From'] != None:
-                break
+            self.assertEqual(transfer['transfer_from'], None)
     
     def test_search_transfers_transfer_to(self):
         response = self.client.get("transfers/search?transfer_to=9229")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for transfer in response.json():
-            if transfer['Transfer_To'] != 9229:
-                break
+            self.assertEqual(transfer['transfer_to'], 9229)
     
     def test_search_transfers_transfer_status(self):
         response = self.client.get("transfers/search?transfer_status=Completed")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for transfer in response.json():
-            if transfer['Transfer_Status'] != "Completed":
-                break
+            self.assertEqual(transfer['transfer_status'], "Completed")
             
     def test_search_transfers_created_at(self):
         response = self.client.get("transfers/search?created_at=2000-03-11T13:11:14Z")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for transfer in response.json():
-            if transfer['Created_At'] != "2000-03-11T13:11:14Z":
-                break
+            self.assertEqual(transfer['Created_At'], "2000-03-11T13:11:14Z")
     
     def test_search_transfers_reference_and_transfer_status(self):
         response = self.client.get("transfers/search?reference=TR00001&transfer_status=Completed")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            if x['Reference']!= "TR00001" and x['Transfer_Status']!= "Completed":
-                break
+            self.assertEqual(x['reference'], "TR00001")
+            self.assertEqual(x['transfer_status'], "Completed")
     
     def test_search_transfers_reference_and_transfer_from(self):
         response = self.client.get("transfers/search?reference=TR00001&transfer_from=None")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            if x['Reference']!= "TR00001" and x['Transfer_From']!= None:
-                break
+            self.assertEqual(x['reference'], "TR00001")
+            self.assertEqual(x['transfer_from'], None)
     
     def test_search_transfers_reference_and_transfer_to(self):
         response = self.client.get("transfers/search?reference=TR00001&transfer_to=2")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            if x['Reference']!= "TR00001" and x['Transfer_To']!= 2:
-                break
+            self.assertEqual(x['reference'], "TR00001")
+            self.assertEqual(x['transfer_to'], 2)
 
     # POST tests
     def test_4create_transfer(self):

--- a/C#api/Tests/test_transfers.py
+++ b/C#api/Tests/test_transfers.py
@@ -62,45 +62,52 @@ class ApiTransfersTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
     
     def test_search_transfers_reference(self):
-        response = self.client.get("transfers?reference=TRANS123")
+        response = self.client.get("transfers?reference=TR00001")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()), 1)
-        self.assertEqual(response.json()[0]['Reference'], "TRANS123")
+        self.assertEqual(len(response.json())> 0, True)
+        self.assertEqual(response.json()[0]['Reference'], "TR00001")
     
     def test_search_transfers_transfer_from(self):
-        response = self.client.get("transfers?transfer_from=1")
+        response = self.client.get("transfers?transfer_from=None")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Transfer_From'], None)
     
     def test_search_transfers_transfer_to(self):
-        response = self.client.get("transfers?transfer_to=2")
+        response = self.client.get("transfers?transfer_to=9229")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Transfer_To'], 9229)
     
     def test_search_transfers_transfer_status(self):
-        response = self.client.get("transfers?transfer_status=Scheduled")
+        response = self.client.get("transfers?transfer_status=Completed")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Transfer_Status'], "Completed")
     
     def test_search_transfers_created_at(self):
-        response = self.client.get("transfers?created_at=2024-11-14T16:10:14.227318")
+        response = self.client.get("transfers?created_at=2000-03-11T13:11:14Z")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Created_At'], "2000-03-11T13:11:14Z")
     
     def test_search_transfers_reference_and_transfer_status(self):
-        response = self.client.get("transfers?reference=TRANS123&transfer_status=Scheduled")
+        response = self.client.get("transfers?reference=TR00001&transfer_status=Completed")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Reference'], "TR00001", "Completed")
     
     def test_search_transfers_reference_and_transfer_from(self):
-        response = self.client.get("transfers?reference=TRANS123&transfer_from=1")
+        response = self.client.get("transfers?reference=TR00001&transfer_from=None")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Reference'], "TR00001", "None")
     
     def test_search_transfers_reference_and_transfer_to(self):
-        response = self.client.get("transfers?reference=TRANS123&transfer_to=2")
+        response = self.client.get("transfers?reference=TR00001&transfer_to=2")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Reference'], "TR00001", 9229)
 
     # POST tests
     def test_4create_transfer(self):

--- a/C#api/Tests/test_transfers.py
+++ b/C#api/Tests/test_transfers.py
@@ -64,62 +64,62 @@ class ApiTransfersTests(unittest.TestCase):
     def test_search_transfers_reference(self):
         response = self.client.get("transfers/search?reference=TR00001")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json())> 0, response.json())
+        self.assertTrue(len(response.json())> 0, response.json())
         for reference in response.json():
-            self.assertEqual(reference['reference'], "TR00001")
+            self.assertEqual(reference['Reference'], "TR00001")
     
     def test_search_transfers_transfer_from(self):
-        response = self.client.get("transfers/search?transfer_from=None")
+        response = self.client.get("transfers/search?transferfrom=9229")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for transfer in response.json():
-            self.assertEqual(transfer['transfer_from'], None)
+            self.assertEqual(transfer['Transfer_From'], 9229)
     
     def test_search_transfers_transfer_to(self):
-        response = self.client.get("transfers/search?transfer_to=9229")
+        response = self.client.get("transfers/search?transferto=9229")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for transfer in response.json():
-            self.assertEqual(transfer['transfer_to'], 9229)
+            self.assertEqual(transfer['Transfer_To'], 9229)
     
     def test_search_transfers_transfer_status(self):
-        response = self.client.get("transfers/search?transfer_status=Completed")
+        response = self.client.get("transfers/search?transferstatus=Completed")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for transfer in response.json():
-            self.assertEqual(transfer['transfer_status'], "Completed")
+            self.assertEqual(transfer['Transfer_Status'], "Completed")
             
     def test_search_transfers_created_at(self):
-        response = self.client.get("transfers/search?created_at=2000-03-11T13:11:14Z")
+        response = self.client.get("transfers/search?createdat=2000-03-11T13:11:14Z")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for transfer in response.json():
             self.assertEqual(transfer['Created_At'], "2000-03-11T13:11:14Z")
     
     def test_search_transfers_reference_and_transfer_status(self):
-        response = self.client.get("transfers/search?reference=TR00001&transfer_status=Completed")
+        response = self.client.get("transfers/search?reference=TR00001&transferstatus=Completed")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            self.assertEqual(x['reference'], "TR00001")
-            self.assertEqual(x['transfer_status'], "Completed")
+            self.assertEqual(x['Reference'], "TR00001")
+            self.assertEqual(x['Transfer_Status'], "Completed")
     
     def test_search_transfers_reference_and_transfer_from(self):
-        response = self.client.get("transfers/search?reference=TR00001&transfer_from=None")
+        response = self.client.get("transfers/search?reference=TR00002&transferfrom=9229")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            self.assertIn('reference', x)
-            self.assertEqual(x['reference'], "TR00001")
-            self.assertEqual(x['transfer_from'], None)
-    
+            self.assertEqual(x['Reference'], "TR00002")
+            self.assertEqual(x['Transfer_From'], 9229)
+
     def test_search_transfers_reference_and_transfer_to(self):
-        response = self.client.get("transfers/search?reference=TR00001&transfer_to=2")
+        response = self.client.get("transfers/search?reference=TR00001&transferto=9229")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
-            self.assertEqual(x['reference'], "TR00001")
-            self.assertEqual(x['transfer_to'], 2)
+            self.assertIn('Reference', x)
+            self.assertEqual(x['Reference'], "TR00001")
+            self.assertEqual(x['Transfer_To'], 9229)
 
     # POST tests
     def test_4create_transfer(self):

--- a/C#api/Tests/test_transfers.py
+++ b/C#api/Tests/test_transfers.py
@@ -109,6 +109,7 @@ class ApiTransfersTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for x in response.json():
+            self.assertIn('reference', x)
             self.assertEqual(x['reference'], "TR00001")
             self.assertEqual(x['transfer_from'], None)
     

--- a/C#api/Tests/test_transfers.py
+++ b/C#api/Tests/test_transfers.py
@@ -62,7 +62,7 @@ class ApiTransfersTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
     
     def test_search_transfers_reference(self):
-        response = self.client.get("transfers?reference=TR00001")
+        response = self.client.get("transfers/search?reference=TR00001")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json())> 0, True)
         for reference in response.json():
@@ -70,7 +70,7 @@ class ApiTransfersTests(unittest.TestCase):
                 break
     
     def test_search_transfers_transfer_from(self):
-        response = self.client.get("transfers?transfer_from=None")
+        response = self.client.get("transfers/search?transfer_from=None")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for transfer in response.json():
@@ -78,7 +78,7 @@ class ApiTransfersTests(unittest.TestCase):
                 break
     
     def test_search_transfers_transfer_to(self):
-        response = self.client.get("transfers?transfer_to=9229")
+        response = self.client.get("transfers/search?transfer_to=9229")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for transfer in response.json():
@@ -86,7 +86,7 @@ class ApiTransfersTests(unittest.TestCase):
                 break
     
     def test_search_transfers_transfer_status(self):
-        response = self.client.get("transfers?transfer_status=Completed")
+        response = self.client.get("transfers/search?transfer_status=Completed")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for transfer in response.json():
@@ -94,7 +94,7 @@ class ApiTransfersTests(unittest.TestCase):
                 break
             
     def test_search_transfers_created_at(self):
-        response = self.client.get("transfers?created_at=2000-03-11T13:11:14Z")
+        response = self.client.get("transfers/search?created_at=2000-03-11T13:11:14Z")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for transfer in response.json():
@@ -102,7 +102,7 @@ class ApiTransfersTests(unittest.TestCase):
                 break
     
     def test_search_transfers_reference_and_transfer_status(self):
-        response = self.client.get("transfers?reference=TR00001&transfer_status=Completed")
+        response = self.client.get("transfers/search?reference=TR00001&transfer_status=Completed")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for x in response.json():
@@ -110,7 +110,7 @@ class ApiTransfersTests(unittest.TestCase):
                 break
     
     def test_search_transfers_reference_and_transfer_from(self):
-        response = self.client.get("transfers?reference=TR00001&transfer_from=None")
+        response = self.client.get("transfers/search?reference=TR00001&transfer_from=None")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for x in response.json():
@@ -118,7 +118,7 @@ class ApiTransfersTests(unittest.TestCase):
                 break
     
     def test_search_transfers_reference_and_transfer_to(self):
-        response = self.client.get("transfers?reference=TR00001&transfer_to=2")
+        response = self.client.get("transfers/search?reference=TR00001&transfer_to=2")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for x in response.json():

--- a/C#api/Tests/test_transfers.py
+++ b/C#api/Tests/test_transfers.py
@@ -86,6 +86,21 @@ class ApiTransfersTests(unittest.TestCase):
         response = self.client.get("transfers?created_at=2024-11-14T16:10:14.227318")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_transfers_reference_and_transfer_status(self):
+        response = self.client.get("transfers?reference=TRANS123&transfer_status=Scheduled")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_transfers_reference_and_transfer_from(self):
+        response = self.client.get("transfers?reference=TRANS123&transfer_from=1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_transfers_reference_and_transfer_to(self):
+        response = self.client.get("transfers?reference=TRANS123&transfer_to=2")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
 
     # POST tests
     def test_4create_transfer(self):

--- a/C#api/Tests/test_warehouses.py
+++ b/C#api/Tests/test_warehouses.py
@@ -61,106 +61,96 @@ class ApiWarehousesTests(unittest.TestCase):
     def test_search_warehouses_by_name(self):
         response = self.client.get(f"warehouses/search?name=Heemskerk cargo hub")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            if item['Name'] != "Heemskerk cargo hub":
-                break
+            self.assertEqual(item['Name'], "Heemskerk cargo hub")
     
     def test_search_warehouses_by_code(self):
         response = self.client.get(f"warehouses/search?code=YQZZNL56")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            if item['Code'] != "YQZZNL56":
-               break
+            self.assertEqual(item['Code'], "YQZZNL56")
     
     def test_search_warehouses_by_address(self):
         response = self.client.get(f"warehouses/search?address=Karlijndreef 281")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for item in response.json():
-            if item['Address'] != "Karlijndreef 281":
-                break
+            self.assertEqual(item['Address'], "Karlijndreef 281")
     
     def test_search_warehouses_by_zip(self):
         response = self.client.get(f"warehouses/search?zip=4002 AS")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for response in response.json():
-            if response['Zip'] != "4002 AS":
-                break
+            self.assertEqual(response['Zip'], "4002 AS")
     
     def test_search_warehouses_by_city(self):
         response = self.client.get(f"warehouses/search?city=Heemskerk")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for response in response.json():
-            if response['City'] != "Heemskerk":
-                break
+            self.assertEqual(response['City'], "Heemskerk")
     
     def test_search_warehouses_by_province(self):
         response = self.client.get(f"warehouses/search?province=Friesland")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for response in response.json():
-            if response['Province'] != "Friesland":
-                break
+            self.assertEqual(response['Province'], "Friesland")
     
     def test_search_warehouses_by_country(self):
         response = self.client.get(f"warehouses/search?country=NL")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for response in response.json():
-            if response['Country'] != "NL":
-                break
+            self.assertEqual(response['Country'], "NL")
     
     def test_search_warehouses_by_contact_name(self):
         response = self.client.get(f"warehouses/search?contact_name=Fem Keijzer")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for response in response.json():
-            if response['Contact']['Name'] != "Fem Keijzer":
-                break
+            self.assertEqual(response['Contact']['Name'], "Fem Keijzer")
     
     def test_search_warehouses_by_contact_phone(self):
         response = self.client.get(f"warehouses/search?contact_phone=(078) 0013363")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for response in response.json():
-            if response['Contact']['Phone'] != "(078) 0013363":
-                break
+            self.assertEqual(response['Contact']['Phone'], "(078) 0013363")
             
     def test_search_warehouses_by_contact_email(self):
         response = self.client.get(f"warehouses/search?contact_email=blamore@example.net")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for response in response.json():
-            if response['Contact']['Email'] != "blamore@example.net":
-                break
+            self.assertTrue(response['Contact']['Email'], "blamore@example.net")
     
     def test_search_warehouses_by_city_and_province(self):
         response = self.client.get(f"warehouses/search?city=Heemskerk&province=Friesland")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for response in response.json():
-            if response['City'] != "Heemskerk" and response['Province'] != "Friesland":
-                break
+            self.assertEqual(response['City'], "Heemskerk")
+            self.assertEqual(response['Province'], "Friesland")
     
     def test_search_warehouses_by_city_and_country(self):
         response = self.client.get(f"warehouses/search?city=Heemskerk&country=NL")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for response in response.json():
-            if response['City'] != "Heemskerk" and response['Country'] != "NL":
-                break
+            self.assertEqual(response['City'], "Heemskerk")
+            self.assertEqual(response['Country'], "NL")
     
     def test_search_warehouses_by_province_and_country(self):
         response = self.client.get(f"warehouses/search?province=Friesland&country=NL")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, True)
+        self.assertTrue(len(response.json()) > 0, response.json())
         for response in response.json():
-            if response['Province'] != "Friesland" and response['Country'] != "NL":
-                break
+            self.assertEqual(response['province'], "Friesland")
+            self.assertEqual(response['country'], "Friesland")
 
     # POST tests
     

--- a/C#api/Tests/test_warehouses.py
+++ b/C#api/Tests/test_warehouses.py
@@ -62,79 +62,105 @@ class ApiWarehousesTests(unittest.TestCase):
         response = self.client.get(f"warehouses?name=Heemskerk cargo hub")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Name'], "Heemskerk cargo hub")
+        for item in response.json():
+            if item['Name'] != "Heemskerk cargo hub":
+                break
     
     def test_search_warehouses_by_code(self):
         response = self.client.get(f"warehouses?code=YQZZNL56")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Code'], "YQZZNL56")
+        for item in response.json():
+            if item['Code'] != "YQZZNL56":
+               break
     
     def test_search_warehouses_by_address(self):
         response = self.client.get(f"warehouses?address=Karlijndreef 281")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Address'], "Karlijndreef 281")
+        for item in response.json():
+            if item['Address'] != "Karlijndreef 281":
+                break
     
     def test_search_warehouses_by_zip(self):
         response = self.client.get(f"warehouses?zip=4002 AS")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Zip'], "4002 AS")
+        for response in response.json():
+            if response['Zip'] != "4002 AS":
+                break
     
     def test_search_warehouses_by_city(self):
         response = self.client.get(f"warehouses?city=Heemskerk")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['City'], "Heemskerk")
+        for response in response.json():
+            if response['City'] != "Heemskerk":
+                break
     
     def test_search_warehouses_by_province(self):
         response = self.client.get(f"warehouses?province=Friesland")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Province'], "Friesland")
+        for response in response.json():
+            if response['Province'] != "Friesland":
+                break
     
     def test_search_warehouses_by_country(self):
         response = self.client.get(f"warehouses?country=NL")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Country'], "NL")
+        for response in response.json():
+            if response['Country'] != "NL":
+                break
     
     def test_search_warehouses_by_contact_name(self):
         response = self.client.get(f"warehouses?contact_name=Fem Keijzer")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Contact']['Name'], "Fem Keijzer")
+        for response in response.json():
+            if response['Contact']['Name'] != "Fem Keijzer":
+                break
     
     def test_search_warehouses_by_contact_phone(self):
         response = self.client.get(f"warehouses?contact_phone=(078) 0013363")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Contact']['Phone'], "(078) 0013363")
-    
+        for response in response.json():
+            if response['Contact']['Phone'] != "(078) 0013363":
+                break
+            
     def test_search_warehouses_by_contact_email(self):
         response = self.client.get(f"warehouses?contact_email=blamore@example.net")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Contact']['Email'], "blamore@example.net")
+        for response in response.json():
+            if response['Contact']['Email'] != "blamore@example.net":
+                break
     
     def test_search_warehouses_by_city_and_province(self):
         response = self.client.get(f"warehouses?city=Heemskerk&province=Friesland")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['City'], "Heemskerk", "Friesland")
+        for response in response.json():
+            if response['City'] != "Heemskerk" and response['Province'] != "Friesland":
+                break
     
     def test_search_warehouses_by_city_and_country(self):
         response = self.client.get(f"warehouses?city=Heemskerk&country=NL")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['City'], "Heemskerk", "NL")
+        for response in response.json():
+            if response['City'] != "Heemskerk" and response['Country'] != "NL":
+                break
     
     def test_search_warehouses_by_province_and_country(self):
         response = self.client.get(f"warehouses?province=Friesland&country=NL")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
-        self.assertEqual(response.json()[0]['Province'], "Friesland", "NL")
+        for response in response.json():
+            if response['Province'] != "Friesland" and response['Country'] != "NL":
+                break
 
     # POST tests
     

--- a/C#api/Tests/test_warehouses.py
+++ b/C#api/Tests/test_warehouses.py
@@ -57,6 +57,56 @@ class ApiWarehousesTests(unittest.TestCase):
     def test_3get_non_existent_warehouse(self):
         response = self.client.get("warehouses/-1")
         self.assertEqual(response.status_code, 404)
+    
+    def test_search_warehouses_by_name(self):
+        response = self.client.get(f"warehouses?name=New")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_warehouses_by_code(self):
+        response = self.client.get(f"warehouses?code=ABC123")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_warehouses_by_address(self):
+        response = self.client.get(f"warehouses?address=123")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_warehouses_by_zip(self):
+        response = self.client.get(f"warehouses?zip=12345")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_warehouses_by_city(self):
+        response = self.client.get(f"warehouses?city=Storageville")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_warehouses_by_province(self):
+        response = self.client.get(f"warehouses?province=Storagestate")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_warehouses_by_country(self):
+        response = self.client.get(f"warehouses?country=Storageland")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_warehouses_by_contact_name(self):
+        response = self.client.get(f"warehouses?contact_name=John")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_warehouses_by_contact_phone(self):
+        response = self.client.get(f"warehouses?contact_phone=123-456-7890")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_warehouses_by_contact_email(self):
+        response = self.client.get(f"warehouses?contact_email=john@example.com")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
 
     # POST tests
     

--- a/C#api/Tests/test_warehouses.py
+++ b/C#api/Tests/test_warehouses.py
@@ -107,6 +107,21 @@ class ApiWarehousesTests(unittest.TestCase):
         response = self.client.get(f"warehouses?contact_email=john@example.com")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_warehouses_by_city_and_province(self):
+        response = self.client.get(f"warehouses?city=Storageville&province=Storagestate")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_warehouses_by_city_and_country(self):
+        response = self.client.get(f"warehouses?city=Storageville&country=Storageland")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
+    
+    def test_search_warehouses_by_province_and_country(self):
+        response = self.client.get(f"warehouses?province=Storagestate&country=Storageland")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json()) > 0)
 
     # POST tests
     

--- a/C#api/Tests/test_warehouses.py
+++ b/C#api/Tests/test_warehouses.py
@@ -59,7 +59,7 @@ class ApiWarehousesTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
     
     def test_search_warehouses_by_name(self):
-        response = self.client.get(f"warehouses?name=Heemskerk cargo hub")
+        response = self.client.get(f"warehouses/search?name=Heemskerk cargo hub")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for item in response.json():
@@ -67,7 +67,7 @@ class ApiWarehousesTests(unittest.TestCase):
                 break
     
     def test_search_warehouses_by_code(self):
-        response = self.client.get(f"warehouses?code=YQZZNL56")
+        response = self.client.get(f"warehouses/search?code=YQZZNL56")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for item in response.json():
@@ -75,7 +75,7 @@ class ApiWarehousesTests(unittest.TestCase):
                break
     
     def test_search_warehouses_by_address(self):
-        response = self.client.get(f"warehouses?address=Karlijndreef 281")
+        response = self.client.get(f"warehouses/search?address=Karlijndreef 281")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for item in response.json():
@@ -83,7 +83,7 @@ class ApiWarehousesTests(unittest.TestCase):
                 break
     
     def test_search_warehouses_by_zip(self):
-        response = self.client.get(f"warehouses?zip=4002 AS")
+        response = self.client.get(f"warehouses/search?zip=4002 AS")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for response in response.json():
@@ -91,7 +91,7 @@ class ApiWarehousesTests(unittest.TestCase):
                 break
     
     def test_search_warehouses_by_city(self):
-        response = self.client.get(f"warehouses?city=Heemskerk")
+        response = self.client.get(f"warehouses/search?city=Heemskerk")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for response in response.json():
@@ -99,7 +99,7 @@ class ApiWarehousesTests(unittest.TestCase):
                 break
     
     def test_search_warehouses_by_province(self):
-        response = self.client.get(f"warehouses?province=Friesland")
+        response = self.client.get(f"warehouses/search?province=Friesland")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for response in response.json():
@@ -107,7 +107,7 @@ class ApiWarehousesTests(unittest.TestCase):
                 break
     
     def test_search_warehouses_by_country(self):
-        response = self.client.get(f"warehouses?country=NL")
+        response = self.client.get(f"warehouses/search?country=NL")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for response in response.json():
@@ -115,7 +115,7 @@ class ApiWarehousesTests(unittest.TestCase):
                 break
     
     def test_search_warehouses_by_contact_name(self):
-        response = self.client.get(f"warehouses?contact_name=Fem Keijzer")
+        response = self.client.get(f"warehouses/search?contact_name=Fem Keijzer")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for response in response.json():
@@ -123,7 +123,7 @@ class ApiWarehousesTests(unittest.TestCase):
                 break
     
     def test_search_warehouses_by_contact_phone(self):
-        response = self.client.get(f"warehouses?contact_phone=(078) 0013363")
+        response = self.client.get(f"warehouses/search?contact_phone=(078) 0013363")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for response in response.json():
@@ -131,7 +131,7 @@ class ApiWarehousesTests(unittest.TestCase):
                 break
             
     def test_search_warehouses_by_contact_email(self):
-        response = self.client.get(f"warehouses?contact_email=blamore@example.net")
+        response = self.client.get(f"warehouses/search?contact_email=blamore@example.net")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for response in response.json():
@@ -139,7 +139,7 @@ class ApiWarehousesTests(unittest.TestCase):
                 break
     
     def test_search_warehouses_by_city_and_province(self):
-        response = self.client.get(f"warehouses?city=Heemskerk&province=Friesland")
+        response = self.client.get(f"warehouses/search?city=Heemskerk&province=Friesland")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for response in response.json():
@@ -147,7 +147,7 @@ class ApiWarehousesTests(unittest.TestCase):
                 break
     
     def test_search_warehouses_by_city_and_country(self):
-        response = self.client.get(f"warehouses?city=Heemskerk&country=NL")
+        response = self.client.get(f"warehouses/search?city=Heemskerk&country=NL")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for response in response.json():
@@ -155,7 +155,7 @@ class ApiWarehousesTests(unittest.TestCase):
                 break
     
     def test_search_warehouses_by_province_and_country(self):
-        response = self.client.get(f"warehouses?province=Friesland&country=NL")
+        response = self.client.get(f"warehouses/search?province=Friesland&country=NL")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, True)
         for response in response.json():

--- a/C#api/Tests/test_warehouses.py
+++ b/C#api/Tests/test_warehouses.py
@@ -106,28 +106,7 @@ class ApiWarehousesTests(unittest.TestCase):
         self.assertTrue(len(response.json()) > 0, response.json())
         for response in response.json():
             self.assertEqual(response['Country'], "NL")
-    
-    def test_search_warehouses_by_contact_name(self):
-        response = self.client.get(f"warehouses/search?contact_name=Fem Keijzer")
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, response.json())
-        for response in response.json():
-            self.assertEqual(response['Contact']['Name'], "Fem Keijzer")
-    
-    def test_search_warehouses_by_contact_phone(self):
-        response = self.client.get(f"warehouses/search?contact_phone=(078) 0013363")
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, response.json())
-        for response in response.json():
-            self.assertEqual(response['Contact']['Phone'], "(078) 0013363")
-            
-    def test_search_warehouses_by_contact_email(self):
-        response = self.client.get(f"warehouses/search?contact_email=blamore@example.net")
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, response.json())
-        for response in response.json():
-            self.assertTrue(response['Contact']['Email'], "blamore@example.net")
-    
+      
     def test_search_warehouses_by_city_and_province(self):
         response = self.client.get(f"warehouses/search?city=Heemskerk&province=Friesland")
         self.assertEqual(response.status_code, 200)
@@ -149,8 +128,8 @@ class ApiWarehousesTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
         for response in response.json():
-            self.assertEqual(response['province'], "Friesland")
-            self.assertEqual(response['country'], "Friesland")
+            self.assertEqual(response['Province'], "Friesland")
+            self.assertEqual(response['Country'], "NL")
 
     # POST tests
     

--- a/C#api/Tests/test_warehouses.py
+++ b/C#api/Tests/test_warehouses.py
@@ -59,69 +59,82 @@ class ApiWarehousesTests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
     
     def test_search_warehouses_by_name(self):
-        response = self.client.get(f"warehouses?name=New")
+        response = self.client.get(f"warehouses?name=Heemskerk cargo hub")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Name'], "Heemskerk cargo hub")
     
     def test_search_warehouses_by_code(self):
-        response = self.client.get(f"warehouses?code=ABC123")
+        response = self.client.get(f"warehouses?code=YQZZNL56")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Code'], "YQZZNL56")
     
     def test_search_warehouses_by_address(self):
-        response = self.client.get(f"warehouses?address=123")
+        response = self.client.get(f"warehouses?address=Karlijndreef 281")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Address'], "Karlijndreef 281")
     
     def test_search_warehouses_by_zip(self):
-        response = self.client.get(f"warehouses?zip=12345")
+        response = self.client.get(f"warehouses?zip=4002 AS")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Zip'], "4002 AS")
     
     def test_search_warehouses_by_city(self):
-        response = self.client.get(f"warehouses?city=Storageville")
+        response = self.client.get(f"warehouses?city=Heemskerk")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['City'], "Heemskerk")
     
     def test_search_warehouses_by_province(self):
-        response = self.client.get(f"warehouses?province=Storagestate")
+        response = self.client.get(f"warehouses?province=Friesland")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Province'], "Friesland")
     
     def test_search_warehouses_by_country(self):
-        response = self.client.get(f"warehouses?country=Storageland")
+        response = self.client.get(f"warehouses?country=NL")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Country'], "NL")
     
     def test_search_warehouses_by_contact_name(self):
-        response = self.client.get(f"warehouses?contact_name=John")
+        response = self.client.get(f"warehouses?contact_name=Fem Keijzer")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Contact']['Name'], "Fem Keijzer")
     
     def test_search_warehouses_by_contact_phone(self):
-        response = self.client.get(f"warehouses?contact_phone=123-456-7890")
+        response = self.client.get(f"warehouses?contact_phone=(078) 0013363")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Contact']['Phone'], "(078) 0013363")
     
     def test_search_warehouses_by_contact_email(self):
-        response = self.client.get(f"warehouses?contact_email=john@example.com")
+        response = self.client.get(f"warehouses?contact_email=blamore@example.net")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Contact']['Email'], "blamore@example.net")
     
     def test_search_warehouses_by_city_and_province(self):
-        response = self.client.get(f"warehouses?city=Storageville&province=Storagestate")
+        response = self.client.get(f"warehouses?city=Heemskerk&province=Friesland")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['City'], "Heemskerk", "Friesland")
     
     def test_search_warehouses_by_city_and_country(self):
-        response = self.client.get(f"warehouses?city=Storageville&country=Storageland")
+        response = self.client.get(f"warehouses?city=Heemskerk&country=NL")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['City'], "Heemskerk", "NL")
     
     def test_search_warehouses_by_province_and_country(self):
-        response = self.client.get(f"warehouses?province=Storagestate&country=Storageland")
+        response = self.client.get(f"warehouses?province=Friesland&country=NL")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0)
+        self.assertTrue(len(response.json()) > 0, True)
+        self.assertEqual(response.json()[0]['Province'], "Friesland", "NL")
 
     # POST tests
     

--- a/C#api/models/clients.cs
+++ b/C#api/models/clients.cs
@@ -43,15 +43,20 @@ public class Clients : Base
         return data.Find(x => Convert.ToInt64(x.Id) == clientId);
     }
 
-    public List<Client> SearchClients(string name = null, string address = null, string city = null, string zipCode = null, string province = null ,string country = null, string contactName = null, string contactPhone = null, string contactEmail = null)
+    public List<Client> SearchClients( int? id = null, string name = null, string address = null, string city = null, string zipCode = null, string province = null ,string country = null, string contactName = null, string contactPhone = null, string contactEmail = null)
     {
-        if (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(city) && string.IsNullOrEmpty(country) && string.IsNullOrEmpty(address) && string.IsNullOrEmpty(zipCode) && string.IsNullOrEmpty(province) && string.IsNullOrEmpty(contactName) && string.IsNullOrEmpty(contactPhone) && string.IsNullOrEmpty(contactEmail))
+        if ( id == null && string.IsNullOrEmpty(name) && string.IsNullOrEmpty(city) && string.IsNullOrEmpty(country) && string.IsNullOrEmpty(address) && string.IsNullOrEmpty(zipCode) && string.IsNullOrEmpty(province) && string.IsNullOrEmpty(contactName) && string.IsNullOrEmpty(contactPhone) && string.IsNullOrEmpty(contactEmail))
         {
             throw new ArgumentException("At least one search parameter must be provided.");
         }
 
         var query = data.AsQueryable();
 
+        if (id != null)
+        {
+            query = query.Where(client => Convert.ToInt64(client.Id) == id);
+        }
+        
         if (!string.IsNullOrEmpty(name))
         {
             query = query.Where(client => client.Name.Contains(name, StringComparison.OrdinalIgnoreCase));

--- a/C#api/models/clients.cs
+++ b/C#api/models/clients.cs
@@ -45,7 +45,7 @@ public class Clients : Base
 
     public List<Client> SearchClients(string name = null, string address = null, string city = null, string zipCode = null, string province = null ,string country = null, string contactName = null, string contactPhone = null, string contactEmail = null)
     {
-        if (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(city) && string.IsNullOrEmpty(country))
+        if (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(city) && string.IsNullOrEmpty(country) && string.IsNullOrEmpty(address) && string.IsNullOrEmpty(zipCode) && string.IsNullOrEmpty(province) && string.IsNullOrEmpty(contactName) && string.IsNullOrEmpty(contactPhone) && string.IsNullOrEmpty(contactEmail))
         {
             throw new ArgumentException("At least one search parameter must be provided.");
         }
@@ -95,6 +95,11 @@ public class Clients : Base
         if (!string.IsNullOrEmpty(contactEmail))
         {
             query = query.Where(client => client.Contact_email.Contains(contactEmail, StringComparison.OrdinalIgnoreCase));
+        }
+        
+        if (query.Count() == 0)
+        {
+            throw new ArgumentException("No clients found.");
         }
 
         return query.ToList();

--- a/C#api/models/clients.cs
+++ b/C#api/models/clients.cs
@@ -43,6 +43,28 @@ public class Clients : Base
         return data.Find(x => Convert.ToInt64(x.Id) == clientId);
     }
 
+    public List<Client> SearchClients(string name = null, string city = null, string country = null)
+    {
+        var query = data.AsQueryable();
+
+        if (!string.IsNullOrEmpty(name))
+        {
+            query = query.Where(client => client.Name.Contains(name, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(city))
+        {
+            query = query.Where(client => client.City.Contains(city, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(country))
+        {
+            query = query.Where(client => client.Country.Contains(country, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return query.ToList();
+    }
+
     public bool AddClient(Client client)
     {
         if (data.Any(existingClient => Convert.ToInt64(existingClient.Id) == client.Id))

--- a/C#api/models/clients.cs
+++ b/C#api/models/clients.cs
@@ -43,7 +43,7 @@ public class Clients : Base
         return data.Find(x => Convert.ToInt64(x.Id) == clientId);
     }
 
-    public List<Client> SearchClients(string name = null, string city = null, string country = null)
+    public List<Client> SearchClients(string name = null, string address = null, string city = null, string zipCode = null, string province = null ,string country = null, string contactName = null, string contactPhone = null, string contactEmail = null)
     {
         if (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(city) && string.IsNullOrEmpty(country))
         {
@@ -57,14 +57,44 @@ public class Clients : Base
             query = query.Where(client => client.Name.Contains(name, StringComparison.OrdinalIgnoreCase));
         }
 
+        if (!string.IsNullOrEmpty(address))
+        {
+            query = query.Where(client => client.Address.Contains(address, StringComparison.OrdinalIgnoreCase));
+        }
+
         if (!string.IsNullOrEmpty(city))
         {
             query = query.Where(client => client.City.Contains(city, StringComparison.OrdinalIgnoreCase));
         }
 
+        if (!string.IsNullOrEmpty(zipCode))
+        {
+            query = query.Where(client => client.Zip_code.Contains(zipCode, StringComparison.OrdinalIgnoreCase));
+        }
+        
+        if (!string.IsNullOrEmpty(province))
+        {
+            query = query.Where(client => client.Province.Contains(province, StringComparison.OrdinalIgnoreCase));
+        }
+
         if (!string.IsNullOrEmpty(country))
         {
             query = query.Where(client => client.Country.Contains(country, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(contactName))
+        {
+            query = query.Where(client => client.Contact_name.Contains(contactName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(contactPhone))
+        {
+            query = query.Where(client => client.Contact_phone.Contains(contactPhone, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(contactEmail))
+        {
+            query = query.Where(client => client.Contact_email.Contains(contactEmail, StringComparison.OrdinalIgnoreCase));
         }
 
         return query.ToList();

--- a/C#api/models/clients.cs
+++ b/C#api/models/clients.cs
@@ -74,7 +74,7 @@ public class Clients : Base
         
         if (!string.IsNullOrEmpty(province))
         {
-            query = query.Where(client => client.Province.Contains(province, StringComparison.OrdinalIgnoreCase));
+            query = query.Where(client => client.Province != null && client.Province.Contains(province, StringComparison.OrdinalIgnoreCase));
         }
 
         if (!string.IsNullOrEmpty(country))

--- a/C#api/models/clients.cs
+++ b/C#api/models/clients.cs
@@ -45,6 +45,11 @@ public class Clients : Base
 
     public List<Client> SearchClients(string name = null, string city = null, string country = null)
     {
+        if (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(city) && string.IsNullOrEmpty(country))
+        {
+            throw new ArgumentException("At least one search parameter must be provided.");
+        }
+
         var query = data.AsQueryable();
 
         if (!string.IsNullOrEmpty(name))

--- a/C#api/models/items.cs
+++ b/C#api/models/items.cs
@@ -83,7 +83,7 @@ public class Items : Base
         return true;
     }
 
-    public List<Item> SearchItems(string description = null, string code = null, string upcCode = null, string modelNumber = null, string commodityCode = null, string supplierCode = null, string supplierPartNumber = null, decimal? minPrice = null, decimal? maxPrice = null)
+    public List<Item> SearchItems(string description = null, string code = null, string upcCode = null, string modelNumber = null, string commodityCode = null, string supplierCode = null, string supplierPartNumber = null)
     {
         var query = data.AsQueryable();
 

--- a/C#api/models/items.cs
+++ b/C#api/models/items.cs
@@ -83,7 +83,7 @@ public class Items : Base
         return true;
     }
 
-    public List<Item> SearchItems(string description = null, string code = null, string upcCode = null, string modelNumber = null, string commodityCode = null, string supplierCode = null, string supplierPartNumber = null)
+    public List<Item> SearchItems(string uid = null ,string description = null, string code = null, string upcCode = null, string modelNumber = null, string commodityCode = null, string supplierCode = null, string supplierPartNumber = null)
     {
         if (string.IsNullOrEmpty(description) && string.IsNullOrEmpty(code) && string.IsNullOrEmpty(upcCode) &&
             string.IsNullOrEmpty(modelNumber) && string.IsNullOrEmpty(commodityCode) && string.IsNullOrEmpty(supplierCode) &&
@@ -93,6 +93,11 @@ public class Items : Base
         }
 
         var query = data.AsQueryable();
+
+        if (!string.IsNullOrEmpty(uid))
+        {
+            query = query.Where(item => item.Uid.Contains(uid, StringComparison.OrdinalIgnoreCase));
+        }
 
         if (!string.IsNullOrEmpty(description))
         {

--- a/C#api/models/items.cs
+++ b/C#api/models/items.cs
@@ -85,6 +85,13 @@ public class Items : Base
 
     public List<Item> SearchItems(string description = null, string code = null, string upcCode = null, string modelNumber = null, string commodityCode = null, string supplierCode = null, string supplierPartNumber = null)
     {
+        if (string.IsNullOrEmpty(description) && string.IsNullOrEmpty(code) && string.IsNullOrEmpty(upcCode) &&
+            string.IsNullOrEmpty(modelNumber) && string.IsNullOrEmpty(commodityCode) && string.IsNullOrEmpty(supplierCode) &&
+            string.IsNullOrEmpty(supplierPartNumber))
+        {
+            throw new ArgumentException("At least one search parameter must be provided.");
+        }
+
         var query = data.AsQueryable();
 
         if (!string.IsNullOrEmpty(description))

--- a/C#api/models/items.cs
+++ b/C#api/models/items.cs
@@ -83,6 +83,48 @@ public class Items : Base
         return true;
     }
 
+    public List<Item> SearchItems(string description = null, string code = null, string upcCode = null, string modelNumber = null, string commodityCode = null, string supplierCode = null, string supplierPartNumber = null, decimal? minPrice = null, decimal? maxPrice = null)
+    {
+        var query = data.AsQueryable();
+
+        if (!string.IsNullOrEmpty(description))
+        {
+            query = query.Where(item => item.Description.Contains(description, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(code))
+        {
+            query = query.Where(item => item.Code.Contains(code, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(upcCode))
+        {
+            query = query.Where(item => item.Upc_Code.Contains(upcCode, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(modelNumber))
+        {
+            query = query.Where(item => item.Model_Number.Contains(modelNumber, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(commodityCode))
+        {
+            query = query.Where(item => item.Commodity_Code.Contains(commodityCode, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(supplierCode))
+        {
+            query = query.Where(item => item.Supplier_Code.Contains(supplierCode, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(supplierPartNumber))
+        {
+            query = query.Where(item => item.Supplier_Part_Number.Contains(supplierPartNumber, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return query.ToList();
+    }
+
     public bool UpdateItem(string itemId, Item item)
     {
         if ((item.Uid != itemId))

--- a/C#api/models/locations.cs
+++ b/C#api/models/locations.cs
@@ -42,6 +42,38 @@ public class Locations : Base
         return data.Where(location => location.Warehouse_Id == warehouseId).ToList();
     }
 
+    public List<Location> SearchLocations(string name = null, string created_At = null, string updated_At = null,int? warehouseId = null, string code = null)
+    {
+        var query = data.AsQueryable();
+
+        if (!string.IsNullOrEmpty(name))
+        {
+            query = query.Where(location => location.Name.Contains(name, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (warehouseId.HasValue)
+        {
+            query = query.Where(location => location.Warehouse_Id == warehouseId.Value);
+        }
+
+        if (!string.IsNullOrEmpty(code))
+        {
+            query = query.Where(location => location.Code.Contains(code, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(created_At))
+        {
+            query = query.Where(location => location.Created_At.Contains(created_At, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(updated_At))
+        {
+            query = query.Where(location => location.Updated_At.Contains(updated_At, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return query.ToList();
+    }
+
     public bool AddLocation(Location location)
     {
         if (data.Any(existingLocation => existingLocation.Id == location.Id))

--- a/C#api/models/locations.cs
+++ b/C#api/models/locations.cs
@@ -42,8 +42,14 @@ public class Locations : Base
         return data.Where(location => location.Warehouse_Id == warehouseId).ToList();
     }
 
-    public List<Location> SearchLocations(string name = null, string created_At = null, string updated_At = null,int? warehouseId = null, string code = null)
+    public List<Location> SearchLocations(string name = null, string created_At = null, string updated_At = null, int? warehouseId = null, string code = null)
     {
+        if (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(created_At) && string.IsNullOrEmpty(updated_At) &&
+            !warehouseId.HasValue && string.IsNullOrEmpty(code))
+        {
+            throw new ArgumentException("At least one search parameter must be provided.");
+        }
+
         var query = data.AsQueryable();
 
         if (!string.IsNullOrEmpty(name))

--- a/C#api/models/locations.cs
+++ b/C#api/models/locations.cs
@@ -42,15 +42,20 @@ public class Locations : Base
         return data.Where(location => location.Warehouse_Id == warehouseId).ToList();
     }
 
-    public List<Location> SearchLocations(string name = null, string created_At = null, string updated_At = null, int? warehouseId = null, string code = null)
+    public List<Location> SearchLocations(int? id = null,string name = null, string created_At = null, string updated_At = null, int? warehouseId = null, string code = null)
     {
-        if (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(created_At) && string.IsNullOrEmpty(updated_At) &&
+        if (id == null && string.IsNullOrEmpty(name) && string.IsNullOrEmpty(created_At) && string.IsNullOrEmpty(updated_At) &&
             !warehouseId.HasValue && string.IsNullOrEmpty(code))
         {
             throw new ArgumentException("At least one search parameter must be provided.");
         }
 
         var query = data.AsQueryable();
+
+        if (id.HasValue)
+        {
+            query = query.Where(location => location.Id == id.Value);
+        }
 
         if (!string.IsNullOrEmpty(name))
         {

--- a/C#api/models/orders.cs
+++ b/C#api/models/orders.cs
@@ -90,9 +90,9 @@ public class Orders : Base
         return true;
     }
 
-    public List<Order> SearchOrders(int? sourceId = null, string orderStatus = null, string orderDate = null, string requestDate = null, string reference = null, string referenceExtra = null, string notes = null, string shippingNotes = null, string pickingNotes = null, int? warehouseId = null, int? shipTo = null, int? billTo = null, int? shipmentId = null, string created_At = null, string updated_At = null)
+    public List<Order> SearchOrders(int? id = null,int? sourceId = null, string orderStatus = null, string orderDate = null, string requestDate = null, string reference = null, string referenceExtra = null, string notes = null, string shippingNotes = null, string pickingNotes = null, int? warehouseId = null, int? shipTo = null, int? billTo = null, int? shipmentId = null, string created_At = null, string updated_At = null)
     {
-        if (!sourceId.HasValue && string.IsNullOrEmpty(orderStatus) && string.IsNullOrEmpty(orderDate) && string.IsNullOrEmpty(requestDate) &&
+        if (id == null && !sourceId.HasValue && string.IsNullOrEmpty(orderStatus) && string.IsNullOrEmpty(orderDate) && string.IsNullOrEmpty(requestDate) &&
             string.IsNullOrEmpty(reference) && string.IsNullOrEmpty(referenceExtra) && string.IsNullOrEmpty(notes) &&
             string.IsNullOrEmpty(shippingNotes) && string.IsNullOrEmpty(pickingNotes) && !warehouseId.HasValue &&
             !shipTo.HasValue && !billTo.HasValue && !shipmentId.HasValue && string.IsNullOrEmpty(created_At) && string.IsNullOrEmpty(updated_At))
@@ -101,6 +101,10 @@ public class Orders : Base
         }
 
         var query = data.AsQueryable();
+        if (id.HasValue)
+        {
+            query = query.Where(order => order.Id == id.Value);
+        }
 
         if (sourceId.HasValue)
         {

--- a/C#api/models/orders.cs
+++ b/C#api/models/orders.cs
@@ -90,13 +90,21 @@ public class Orders : Base
         return true;
     }
 
-    public List<Order> SearchOrders(int? sourceId = null, string orderStatus = null, string orderDate = null, string requestDate = null, string reference = null, string referenceExtra = null, string notes = null, string shippingNotes = null, string pickingNotes = null, int? warehouseId = null, int? shipTo = null, int? billTo = null, int? shipmentId = null , string created_At = null, string updated_At = null)
+    public List<Order> SearchOrders(int? sourceId = null, string orderStatus = null, string orderDate = null, string requestDate = null, string reference = null, string referenceExtra = null, string notes = null, string shippingNotes = null, string pickingNotes = null, int? warehouseId = null, int? shipTo = null, int? billTo = null, int? shipmentId = null, string created_At = null, string updated_At = null)
     {
+        if (!sourceId.HasValue && string.IsNullOrEmpty(orderStatus) && string.IsNullOrEmpty(orderDate) && string.IsNullOrEmpty(requestDate) &&
+            string.IsNullOrEmpty(reference) && string.IsNullOrEmpty(referenceExtra) && string.IsNullOrEmpty(notes) &&
+            string.IsNullOrEmpty(shippingNotes) && string.IsNullOrEmpty(pickingNotes) && !warehouseId.HasValue &&
+            !shipTo.HasValue && !billTo.HasValue && !shipmentId.HasValue && string.IsNullOrEmpty(created_At) && string.IsNullOrEmpty(updated_At))
+        {
+            throw new ArgumentException("At least one search parameter must be provided.");
+        }
+
         var query = data.AsQueryable();
 
-        if (!string.IsNullOrEmpty(reference))
+        if (sourceId.HasValue)
         {
-            query = query.Where(order => order.Reference.Contains(reference, StringComparison.OrdinalIgnoreCase));
+            query = query.Where(order => order.Source_Id == sourceId.Value);
         }
 
         if (!string.IsNullOrEmpty(orderStatus))
@@ -104,59 +112,71 @@ public class Orders : Base
             query = query.Where(order => order.Order_Status.Contains(orderStatus, StringComparison.OrdinalIgnoreCase));
         }
 
-        if (sourceId.HasValue)
+        if (!string.IsNullOrEmpty(orderDate))
         {
-            query = query.Where(order => order.Source_Id == sourceId.Value);
+            query = query.Where(order => order.Order_Date.Contains(orderDate, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(requestDate))
+        {
+            query = query.Where(order => order.Request_Date.Contains(requestDate, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(reference))
+        {
+            query = query.Where(order => order.Reference.Contains(reference, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(referenceExtra))
+        {
+            query = query.Where(order => order.Reference_Extra.Contains(referenceExtra, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(notes))
+        {
+            query = query.Where(order => order.Notes.Contains(notes, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(shippingNotes))
+        {
+            query = query.Where(order => order.Shipping_Notes.Contains(shippingNotes, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(pickingNotes))
+        {
+            query = query.Where(order => order.Picking_Notes.Contains(pickingNotes, StringComparison.OrdinalIgnoreCase));
         }
 
         if (warehouseId.HasValue)
         {
             query = query.Where(order => order.Warehouse_Id == warehouseId.Value);
         }
+
         if (shipTo.HasValue)
         {
             query = query.Where(order => order.Ship_To == shipTo.Value);
         }
+
         if (billTo.HasValue)
         {
             query = query.Where(order => order.Bill_To == billTo.Value);
         }
+
         if (shipmentId.HasValue)
         {
             query = query.Where(order => order.Shipment_Id == shipmentId.Value);
         }
-        if (!string.IsNullOrEmpty(orderDate))
-        {
-            query = query.Where(order => order.Order_Date.Contains(orderDate, StringComparison.OrdinalIgnoreCase));
-        }
-        if (!string.IsNullOrEmpty(requestDate))
-        {
-            query = query.Where(order => order.Request_Date.Contains(requestDate, StringComparison.OrdinalIgnoreCase));
-        }
-        if (!string.IsNullOrEmpty(referenceExtra))
-        {
-            query = query.Where(order => order.Reference_Extra.Contains(referenceExtra, StringComparison.OrdinalIgnoreCase));
-        }
-        if (!string.IsNullOrEmpty(notes))
-        {
-            query = query.Where(order => order.Notes.Contains(notes, StringComparison.OrdinalIgnoreCase));
-        }
-        if (!string.IsNullOrEmpty(shippingNotes))
-        {
-            query = query.Where(order => order.Shipping_Notes.Contains(shippingNotes, StringComparison.OrdinalIgnoreCase));
-        }
-        if (!string.IsNullOrEmpty(pickingNotes))
-        {
-            query = query.Where(order => order.Picking_Notes.Contains(pickingNotes, StringComparison.OrdinalIgnoreCase));
-        }
+
         if (!string.IsNullOrEmpty(created_At))
         {
             query = query.Where(order => order.Created_At.Contains(created_At, StringComparison.OrdinalIgnoreCase));
         }
+
         if (!string.IsNullOrEmpty(updated_At))
         {
             query = query.Where(order => order.Updated_At.Contains(updated_At, StringComparison.OrdinalIgnoreCase));
         }
+
         return query.ToList();
     }
 

--- a/C#api/models/orders.cs
+++ b/C#api/models/orders.cs
@@ -90,6 +90,77 @@ public class Orders : Base
         return true;
     }
 
+    public List<Order> SearchOrders(int? sourceId = null, string orderStatus = null, string orderDate = null, string requestDate = null, string reference = null, string referenceExtra = null, string notes = null, string shippingNotes = null, string pickingNotes = null, int? warehouseId = null, int? shipTo = null, int? billTo = null, int? shipmentId = null , string created_At = null, string updated_At = null)
+    {
+        var query = data.AsQueryable();
+
+        if (!string.IsNullOrEmpty(reference))
+        {
+            query = query.Where(order => order.Reference.Contains(reference, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(orderStatus))
+        {
+            query = query.Where(order => order.Order_Status.Contains(orderStatus, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (sourceId.HasValue)
+        {
+            query = query.Where(order => order.Source_Id == sourceId.Value);
+        }
+
+        if (warehouseId.HasValue)
+        {
+            query = query.Where(order => order.Warehouse_Id == warehouseId.Value);
+        }
+        if (shipTo.HasValue)
+        {
+            query = query.Where(order => order.Ship_To == shipTo.Value);
+        }
+        if (billTo.HasValue)
+        {
+            query = query.Where(order => order.Bill_To == billTo.Value);
+        }
+        if (shipmentId.HasValue)
+        {
+            query = query.Where(order => order.Shipment_Id == shipmentId.Value);
+        }
+        if (!string.IsNullOrEmpty(orderDate))
+        {
+            query = query.Where(order => order.Order_Date.Contains(orderDate, StringComparison.OrdinalIgnoreCase));
+        }
+        if (!string.IsNullOrEmpty(requestDate))
+        {
+            query = query.Where(order => order.Request_Date.Contains(requestDate, StringComparison.OrdinalIgnoreCase));
+        }
+        if (!string.IsNullOrEmpty(referenceExtra))
+        {
+            query = query.Where(order => order.Reference_Extra.Contains(referenceExtra, StringComparison.OrdinalIgnoreCase));
+        }
+        if (!string.IsNullOrEmpty(notes))
+        {
+            query = query.Where(order => order.Notes.Contains(notes, StringComparison.OrdinalIgnoreCase));
+        }
+        if (!string.IsNullOrEmpty(shippingNotes))
+        {
+            query = query.Where(order => order.Shipping_Notes.Contains(shippingNotes, StringComparison.OrdinalIgnoreCase));
+        }
+        if (!string.IsNullOrEmpty(pickingNotes))
+        {
+            query = query.Where(order => order.Picking_Notes.Contains(pickingNotes, StringComparison.OrdinalIgnoreCase));
+        }
+        if (!string.IsNullOrEmpty(created_At))
+        {
+            query = query.Where(order => order.Created_At.Contains(created_At, StringComparison.OrdinalIgnoreCase));
+        }
+        if (!string.IsNullOrEmpty(updated_At))
+        {
+            query = query.Where(order => order.Updated_At.Contains(updated_At, StringComparison.OrdinalIgnoreCase));
+        }
+        return query.ToList();
+    }
+
+
     public bool UpdateOrder(int orderId, Order order)
     {
         if (Convert.ToInt64(order.Id) != orderId)

--- a/C#api/models/shipments.cs
+++ b/C#api/models/shipments.cs
@@ -76,24 +76,15 @@ public class Shipments : Base
         return true;
     }
 
-     public List<Shipment> SearchShipments(string shipmentStatus = null, string shipmentDate = null, string requestDate = null, int? orderId = null, int? sourceId = null, string carrierCode = null, string serviceCode = null, string paymentType = null)
+     public List<Shipment> SearchShipments(int? orderId = null, int? sourceId = null, string orderDate = null, string requestDate = null, string shipmentDate = null, string shipmentType = null, string created_At = null, string updated_At = null)
     {
+        if (!orderId.HasValue && !sourceId.HasValue && string.IsNullOrEmpty(orderDate) && string.IsNullOrEmpty(requestDate) &&
+            string.IsNullOrEmpty(shipmentDate) && string.IsNullOrEmpty(shipmentType) && string.IsNullOrEmpty(created_At) && string.IsNullOrEmpty(updated_At))
+        {
+            throw new ArgumentException("At least one search parameter must be provided.");
+        }
+
         var query = data.AsQueryable();
-
-        if (!string.IsNullOrEmpty(shipmentStatus))
-        {
-            query = query.Where(shipment => shipment.Shipment_Status.Contains(shipmentStatus, StringComparison.OrdinalIgnoreCase));
-        }
-
-        if (!string.IsNullOrEmpty(shipmentDate))
-        {
-            query = query.Where(shipment => shipment.Shipment_Date.Contains(shipmentDate, StringComparison.OrdinalIgnoreCase));
-        }
-
-        if (!string.IsNullOrEmpty(requestDate))
-        {
-            query = query.Where(shipment => shipment.Request_Date.Contains(requestDate, StringComparison.OrdinalIgnoreCase));
-        }
 
         if (orderId.HasValue)
         {
@@ -105,19 +96,34 @@ public class Shipments : Base
             query = query.Where(shipment => shipment.Source_Id == sourceId.Value);
         }
 
-        if (!string.IsNullOrEmpty(carrierCode))
+        if (!string.IsNullOrEmpty(orderDate))
         {
-            query = query.Where(shipment => shipment.Carrier_Code.Contains(carrierCode, StringComparison.OrdinalIgnoreCase));
+            query = query.Where(shipment => shipment.Order_Date.Contains(orderDate, StringComparison.OrdinalIgnoreCase));
         }
 
-        if (!string.IsNullOrEmpty(serviceCode))
+        if (!string.IsNullOrEmpty(requestDate))
         {
-            query = query.Where(shipment => shipment.Service_Code.Contains(serviceCode, StringComparison.OrdinalIgnoreCase));
+            query = query.Where(shipment => shipment.Request_Date.Contains(requestDate, StringComparison.OrdinalIgnoreCase));
         }
 
-        if (!string.IsNullOrEmpty(paymentType))
+        if (!string.IsNullOrEmpty(shipmentDate))
         {
-            query = query.Where(shipment => shipment.Payment_Type.Contains(paymentType, StringComparison.OrdinalIgnoreCase));
+            query = query.Where(shipment => shipment.Shipment_Date.Contains(shipmentDate, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(shipmentType))
+        {
+            query = query.Where(shipment => shipment.Shipment_Type.Contains(shipmentType, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(created_At))
+        {
+            query = query.Where(shipment => shipment.Created_At.Contains(created_At, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(updated_At))
+        {
+            query = query.Where(shipment => shipment.Updated_At.Contains(updated_At, StringComparison.OrdinalIgnoreCase));
         }
 
         return query.ToList();

--- a/C#api/models/shipments.cs
+++ b/C#api/models/shipments.cs
@@ -76,6 +76,54 @@ public class Shipments : Base
         return true;
     }
 
+     public List<Shipment> SearchShipments(string shipmentStatus = null, string shipmentDate = null, string requestDate = null, int? orderId = null, int? sourceId = null, string carrierCode = null, string serviceCode = null, string paymentType = null)
+    {
+        var query = data.AsQueryable();
+
+        if (!string.IsNullOrEmpty(shipmentStatus))
+        {
+            query = query.Where(shipment => shipment.Shipment_Status.Contains(shipmentStatus, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(shipmentDate))
+        {
+            query = query.Where(shipment => shipment.Shipment_Date.Contains(shipmentDate, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(requestDate))
+        {
+            query = query.Where(shipment => shipment.Request_Date.Contains(requestDate, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (orderId.HasValue)
+        {
+            query = query.Where(shipment => shipment.Order_Id == orderId.Value);
+        }
+
+        if (sourceId.HasValue)
+        {
+            query = query.Where(shipment => shipment.Source_Id == sourceId.Value);
+        }
+
+        if (!string.IsNullOrEmpty(carrierCode))
+        {
+            query = query.Where(shipment => shipment.Carrier_Code.Contains(carrierCode, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(serviceCode))
+        {
+            query = query.Where(shipment => shipment.Service_Code.Contains(serviceCode, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(paymentType))
+        {
+            query = query.Where(shipment => shipment.Payment_Type.Contains(paymentType, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return query.ToList();
+    }
+
+
     public bool UpdateShipment(int shipmentId, Shipment shipment)
     {
         if (shipment.Id != shipmentId)

--- a/C#api/models/shipments.cs
+++ b/C#api/models/shipments.cs
@@ -76,15 +76,20 @@ public class Shipments : Base
         return true;
     }
 
-     public List<Shipment> SearchShipments(int? orderId = null, int? sourceId = null, string orderDate = null, string requestDate = null, string shipmentDate = null, string shipmentType = null, string shipmentStatus = null, string carrierCode = null)
+     public List<Shipment> SearchShipments(int? id = null,int? orderId = null, int? sourceId = null, string orderDate = null, string requestDate = null, string shipmentDate = null, string shipmentType = null, string shipmentStatus = null, string carrierCode = null)
     {
-        if (!orderId.HasValue && !sourceId.HasValue && string.IsNullOrEmpty(orderDate) && string.IsNullOrEmpty(requestDate) &&
+        if (id == null && !orderId.HasValue && !sourceId.HasValue && string.IsNullOrEmpty(orderDate) && string.IsNullOrEmpty(requestDate) &&
             string.IsNullOrEmpty(shipmentDate) && string.IsNullOrEmpty(shipmentType) && string.IsNullOrEmpty(shipmentStatus) && string.IsNullOrEmpty(carrierCode))
         {
             throw new ArgumentException("At least one search parameter must be provided.");
         }
 
         var query = data.AsQueryable();
+        
+        if (id.HasValue)
+        {
+            query = query.Where(shipment => shipment.Id == id.Value);
+        }
 
         if (orderId.HasValue)
         {

--- a/C#api/models/shipments.cs
+++ b/C#api/models/shipments.cs
@@ -76,10 +76,10 @@ public class Shipments : Base
         return true;
     }
 
-     public List<Shipment> SearchShipments(int? orderId = null, int? sourceId = null, string orderDate = null, string requestDate = null, string shipmentDate = null, string shipmentType = null, string created_At = null, string updated_At = null)
+     public List<Shipment> SearchShipments(int? orderId = null, int? sourceId = null, string orderDate = null, string requestDate = null, string shipmentDate = null, string shipmentType = null, string shipmentStatus = null, string carrierCode = null)
     {
         if (!orderId.HasValue && !sourceId.HasValue && string.IsNullOrEmpty(orderDate) && string.IsNullOrEmpty(requestDate) &&
-            string.IsNullOrEmpty(shipmentDate) && string.IsNullOrEmpty(shipmentType) && string.IsNullOrEmpty(created_At) && string.IsNullOrEmpty(updated_At))
+            string.IsNullOrEmpty(shipmentDate) && string.IsNullOrEmpty(shipmentType) && string.IsNullOrEmpty(shipmentStatus) && string.IsNullOrEmpty(carrierCode))
         {
             throw new ArgumentException("At least one search parameter must be provided.");
         }
@@ -116,14 +116,14 @@ public class Shipments : Base
             query = query.Where(shipment => shipment.Shipment_Type.Contains(shipmentType, StringComparison.OrdinalIgnoreCase));
         }
 
-        if (!string.IsNullOrEmpty(created_At))
+        if (!string.IsNullOrEmpty(shipmentStatus))
         {
-            query = query.Where(shipment => shipment.Created_At.Contains(created_At, StringComparison.OrdinalIgnoreCase));
+            query = query.Where(shipment => shipment.Shipment_Status.Contains(shipmentStatus, StringComparison.OrdinalIgnoreCase));
         }
-
-        if (!string.IsNullOrEmpty(updated_At))
+        
+        if (!string.IsNullOrEmpty(carrierCode))
         {
-            query = query.Where(shipment => shipment.Updated_At.Contains(updated_At, StringComparison.OrdinalIgnoreCase));
+            query = query.Where(shipment => shipment.Carrier_Code.Contains(carrierCode, StringComparison.OrdinalIgnoreCase));
         }
 
         return query.ToList();

--- a/C#api/models/suppliers.cs
+++ b/C#api/models/suppliers.cs
@@ -60,6 +60,12 @@ public class Suppliers : Base
 
     public List<Supplier> SearchSuppliers(string name = null, string city = null, string country = null, string code = null, string reference = null)
     {
+        if (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(city) && string.IsNullOrEmpty(country) &&
+            string.IsNullOrEmpty(code) && string.IsNullOrEmpty(reference))
+        {
+            throw new ArgumentException("At least one search parameter must be provided.");
+        }
+
         var query = data.AsQueryable();
 
         if (!string.IsNullOrEmpty(name))
@@ -81,11 +87,11 @@ public class Suppliers : Base
         {
             query = query.Where(supplier => supplier.Code.Contains(code, StringComparison.OrdinalIgnoreCase));
         }
+
         if (!string.IsNullOrEmpty(reference))
         {
             query = query.Where(supplier => supplier.Reference.Contains(reference, StringComparison.OrdinalIgnoreCase));
         }
-
 
         return query.ToList();
     }

--- a/C#api/models/suppliers.cs
+++ b/C#api/models/suppliers.cs
@@ -58,15 +58,20 @@ public class Suppliers : Base
         return true;
     }
 
-    public List<Supplier> SearchSuppliers(string name = null, string city = null, string country = null, string code = null, string reference = null)
+    public List<Supplier> SearchSuppliers(int? id,string name = null, string city = null, string country = null, string code = null, string reference = null)
     {
-        if (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(city) && string.IsNullOrEmpty(country) &&
+        if (id == null && string.IsNullOrEmpty(name) && string.IsNullOrEmpty(city) && string.IsNullOrEmpty(country) &&
             string.IsNullOrEmpty(code) && string.IsNullOrEmpty(reference))
         {
             throw new ArgumentException("At least one search parameter must be provided.");
         }
 
         var query = data.AsQueryable();
+        
+        if (id != null)
+        {
+            query = query.Where(supplier => supplier.Id == id);
+        }
 
         if (!string.IsNullOrEmpty(name))
         {

--- a/C#api/models/suppliers.cs
+++ b/C#api/models/suppliers.cs
@@ -58,7 +58,7 @@ public class Suppliers : Base
         return true;
     }
 
-    public List<Supplier> SearchSuppliers(string name = null, string city = null, string country = null)
+    public List<Supplier> SearchSuppliers(string name = null, string city = null, string country = null, string code = null, string reference = null)
     {
         var query = data.AsQueryable();
 
@@ -76,6 +76,16 @@ public class Suppliers : Base
         {
             query = query.Where(supplier => supplier.Country.Contains(country, StringComparison.OrdinalIgnoreCase));
         }
+
+        if (!string.IsNullOrEmpty(code))
+        {
+            query = query.Where(supplier => supplier.Code.Contains(code, StringComparison.OrdinalIgnoreCase));
+        }
+        if (!string.IsNullOrEmpty(reference))
+        {
+            query = query.Where(supplier => supplier.Reference.Contains(reference, StringComparison.OrdinalIgnoreCase));
+        }
+
 
         return query.ToList();
     }

--- a/C#api/models/suppliers.cs
+++ b/C#api/models/suppliers.cs
@@ -58,6 +58,28 @@ public class Suppliers : Base
         return true;
     }
 
+    public List<Supplier> SearchSuppliers(string name = null, string city = null, string country = null)
+    {
+        var query = data.AsQueryable();
+
+        if (!string.IsNullOrEmpty(name))
+        {
+            query = query.Where(supplier => supplier.Name.Contains(name, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(city))
+        {
+            query = query.Where(supplier => supplier.City.Contains(city, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(country))
+        {
+            query = query.Where(supplier => supplier.Country.Contains(country, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return query.ToList();
+    }
+
     public bool UpdateSupplier(int supplierId, Supplier supplier)
     {
         if (supplier.Id != supplierId)

--- a/C#api/models/transfers.cs
+++ b/C#api/models/transfers.cs
@@ -64,6 +64,38 @@ public class Transfers : Base
         return true;
     }
 
+    public List<Transfer> SearchTransfers(string reference = null, int? transferFrom = null, int? transferTo = null, string transferStatus = null, string createdAt = null)
+    {
+        var query = data.AsQueryable();
+
+        if (!string.IsNullOrEmpty(reference))
+        {
+            query = query.Where(transfer => transfer.Reference.Contains(reference, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (transferFrom.HasValue)
+        {
+            query = query.Where(transfer => transfer.Transfer_From == transferFrom.Value);
+        }
+
+        if (transferTo.HasValue)
+        {
+            query = query.Where(transfer => transfer.Transfer_To == transferTo.Value);
+        }
+
+        if (!string.IsNullOrEmpty(transferStatus))
+        {
+            query = query.Where(transfer => transfer.Transfer_Status.Contains(transferStatus, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(createdAt))
+        {
+            query = query.Where(transfer => transfer.Created_At.Contains(createdAt, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return query.ToList();
+    }
+
     public bool UpdateTransfer(int transferId, Transfer transfer)
     {
         if (transfer.Id != transferId)

--- a/C#api/models/transfers.cs
+++ b/C#api/models/transfers.cs
@@ -66,6 +66,11 @@ public class Transfers : Base
 
     public List<Transfer> SearchTransfers(string reference = null, int? transferFrom = null, int? transferTo = null, string transferStatus = null, string createdAt = null)
     {
+        if (string.IsNullOrEmpty(reference) && !transferFrom.HasValue && !transferTo.HasValue && string.IsNullOrEmpty(transferStatus) && string.IsNullOrEmpty(createdAt))
+        {
+            throw new ArgumentException("At least one search parameter must be provided.");
+        }
+
         var query = data.AsQueryable();
 
         if (!string.IsNullOrEmpty(reference))

--- a/C#api/models/transfers.cs
+++ b/C#api/models/transfers.cs
@@ -64,14 +64,19 @@ public class Transfers : Base
         return true;
     }
 
-    public List<Transfer> SearchTransfers(string reference = null, int? transferFrom = null, int? transferTo = null, string transferStatus = null, string createdAt = null)
+    public List<Transfer> SearchTransfers(int? id = null, string reference = null, int? transferFrom = null, int? transferTo = null, string transferStatus = null, string createdAt = null)
     {
-        if (string.IsNullOrEmpty(reference) && !transferFrom.HasValue && !transferTo.HasValue && string.IsNullOrEmpty(transferStatus) && string.IsNullOrEmpty(createdAt))
+        if (id == null && string.IsNullOrEmpty(reference) && !transferFrom.HasValue && !transferTo.HasValue && string.IsNullOrEmpty(transferStatus) && string.IsNullOrEmpty(createdAt))
         {
             throw new ArgumentException("At least one search parameter must be provided.");
         }
 
         var query = data.AsQueryable();
+        
+        if (id.HasValue)
+        {
+            query = query.Where(transfer => transfer.Id == id.Value);
+        }
 
         if (!string.IsNullOrEmpty(reference))
         {

--- a/C#api/models/warehouses.cs
+++ b/C#api/models/warehouses.cs
@@ -64,6 +64,71 @@ public class Warehouses : Base
         return true;
     }
 
+     public List<Warehouse> SearchWarehouses(string code = null, string name = null, string address = null, string zip = null, string city = null, string provincie = null, string country = null, ContactInfo contact = null ,string? createdAt = null, string? updatedAt = null)
+    {
+        var query = data.AsQueryable();
+
+        if (!string.IsNullOrEmpty(code))
+        {
+            query = query.Where(warehouse => warehouse.Code.Contains(code, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(name))
+        {
+            query = query.Where(warehouse => warehouse.Name.Contains(name, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(address))
+        {
+            query = query.Where(warehouse => warehouse.Address.Contains(address, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(zip))
+        {
+            query = query.Where(warehouse => warehouse.Zip.Contains(zip, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(city))
+        {
+            query = query.Where(warehouse => warehouse.City.Contains(city, StringComparison.OrdinalIgnoreCase));
+        }
+        if (!string.IsNullOrEmpty(provincie))
+        {
+            query = query.Where(warehouse => warehouse.Province.Contains(provincie, StringComparison.OrdinalIgnoreCase));
+        }
+        if (!string.IsNullOrEmpty(country))
+        {
+            query = query.Where(warehouse => warehouse.Country.Contains(country, StringComparison.OrdinalIgnoreCase));
+        }
+        if (contact != null)
+        {
+            if (!string.IsNullOrEmpty(contact.Name))
+            {
+                query = query.Where(warehouse => warehouse.Contact.Name.Contains(contact.Name, StringComparison.OrdinalIgnoreCase));
+            }
+            if (!string.IsNullOrEmpty(contact.Phone))
+            {
+                query = query.Where(warehouse => warehouse.Contact.Phone.Contains(contact.Phone, StringComparison.OrdinalIgnoreCase));
+            }
+            if (!string.IsNullOrEmpty(contact.Email))
+            {
+                query = query.Where(warehouse => warehouse.Contact.Email.Contains(contact.Email, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+
+        if (!string.IsNullOrEmpty(createdAt))
+        {
+            query = query.Where(warehouse => warehouse.Created_At.Contains(createdAt, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(updatedAt))
+        {
+            query = query.Where(warehouse => warehouse.Updated_At.Contains(updatedAt, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return query.ToList();
+    }
+
     public bool UpdateWarehouse(int warehouseId, Warehouse warehouse)
     {
         if (warehouse.Id != warehouseId)

--- a/C#api/models/warehouses.cs
+++ b/C#api/models/warehouses.cs
@@ -64,8 +64,15 @@ public class Warehouses : Base
         return true;
     }
 
-     public List<Warehouse> SearchWarehouses(string code = null, string name = null, string address = null, string zip = null, string city = null, string provincie = null, string country = null, ContactInfo contact = null ,string? createdAt = null, string? updatedAt = null)
+    public List<Warehouse> SearchWarehouses(string code = null, string name = null, string address = null, string zip = null, string city = null, string province = null, string country = null, string createdAt = null, string updatedAt = null)
     {
+        if (string.IsNullOrEmpty(code) && string.IsNullOrEmpty(name) && string.IsNullOrEmpty(address) && string.IsNullOrEmpty(zip) &&
+            string.IsNullOrEmpty(city) && string.IsNullOrEmpty(province) && string.IsNullOrEmpty(country) && 
+            string.IsNullOrEmpty(createdAt) && string.IsNullOrEmpty(updatedAt))
+        {
+            throw new ArgumentException("At least one search parameter must be provided.");
+        }
+
         var query = data.AsQueryable();
 
         if (!string.IsNullOrEmpty(code))
@@ -92,28 +99,15 @@ public class Warehouses : Base
         {
             query = query.Where(warehouse => warehouse.City.Contains(city, StringComparison.OrdinalIgnoreCase));
         }
-        if (!string.IsNullOrEmpty(provincie))
+
+        if (!string.IsNullOrEmpty(province))
         {
-            query = query.Where(warehouse => warehouse.Province.Contains(provincie, StringComparison.OrdinalIgnoreCase));
+            query = query.Where(warehouse => warehouse.Province.Contains(province, StringComparison.OrdinalIgnoreCase));
         }
+
         if (!string.IsNullOrEmpty(country))
         {
             query = query.Where(warehouse => warehouse.Country.Contains(country, StringComparison.OrdinalIgnoreCase));
-        }
-        if (contact != null)
-        {
-            if (!string.IsNullOrEmpty(contact.Name))
-            {
-                query = query.Where(warehouse => warehouse.Contact.Name.Contains(contact.Name, StringComparison.OrdinalIgnoreCase));
-            }
-            if (!string.IsNullOrEmpty(contact.Phone))
-            {
-                query = query.Where(warehouse => warehouse.Contact.Phone.Contains(contact.Phone, StringComparison.OrdinalIgnoreCase));
-            }
-            if (!string.IsNullOrEmpty(contact.Email))
-            {
-                query = query.Where(warehouse => warehouse.Contact.Email.Contains(contact.Email, StringComparison.OrdinalIgnoreCase));
-            }
         }
 
         if (!string.IsNullOrEmpty(createdAt))

--- a/C#api/models/warehouses.cs
+++ b/C#api/models/warehouses.cs
@@ -64,9 +64,9 @@ public class Warehouses : Base
         return true;
     }
 
-    public List<Warehouse> SearchWarehouses(string code = null, string name = null, string address = null, string zip = null, string city = null, string province = null, string country = null, string createdAt = null, string updatedAt = null)
+    public List<Warehouse> SearchWarehouses(int? id = null, string code = null, string name = null, string address = null, string zip = null, string city = null, string province = null, string country = null, string createdAt = null, string updatedAt = null)
     {
-        if (string.IsNullOrEmpty(code) && string.IsNullOrEmpty(name) && string.IsNullOrEmpty(address) && string.IsNullOrEmpty(zip) &&
+        if (id == null && string.IsNullOrEmpty(code) && string.IsNullOrEmpty(name) && string.IsNullOrEmpty(address) && string.IsNullOrEmpty(zip) &&
             string.IsNullOrEmpty(city) && string.IsNullOrEmpty(province) && string.IsNullOrEmpty(country) && 
             string.IsNullOrEmpty(createdAt) && string.IsNullOrEmpty(updatedAt))
         {
@@ -74,6 +74,11 @@ public class Warehouses : Base
         }
 
         var query = data.AsQueryable();
+
+        if (id != null)
+        {
+            query = query.Where(warehouse => warehouse.Id == id);
+        }
 
         if (!string.IsNullOrEmpty(code))
         {


### PR DESCRIPTION
In deze pull request wordt de filtering feature gedaan, met de tests, Updated versie van de filtering feature, met mogelijkheid met een of meerdere filters gebruiken bij 8 models: Clients, Items, Locations, Orders, Shipments, Suppliers, Transfers en Warehouses en er wordt ook de ongeldige search prompt toegevoegd. Ook 2 errors bijgewerkt in tests. Er waren 2 test met errors in requests