### PR TITLE
Filter request

### DIFF
--- a/C#api/Controllers/RequestLogController.cs
+++ b/C#api/Controllers/RequestLogController.cs
@@ -74,7 +74,7 @@ public class RequestLogController : BaseApiController
                 if (parts.Length < 4) continue;
 
                 var logModel = parts[1].Split(':')[1].Trim();
-                var logUser = parts[0].Split(new[] { "made by" }, StringSplitOptions.None)[1].Trim().Split(' ')[0];
+                var logUser = parts[0].Split(new[] { "made by" }, StringSplitOptions.None)[1].Trim();
                 var logDate = parts[3].Split(':')[1].Trim().Split(' ')[0];
 
                 if (!string.IsNullOrEmpty(model) && !logModel.Equals(model, StringComparison.OrdinalIgnoreCase))

--- a/C#api/Controllers/RequestLogController.cs
+++ b/C#api/Controllers/RequestLogController.cs
@@ -75,7 +75,7 @@ public class RequestLogController : BaseApiController
 
                 var logModel = parts[1].Split(':')[1].Trim();
                 var logUser = parts[0].Split(new[] { "made by" }, StringSplitOptions.None)[1].Trim().Split(' ')[0];
-                var logDate = parts[3].Split(':')[1].Trim();
+                var logDate = parts[3].Split(':')[1].Trim().Split(' ')[0];
 
                 if (!string.IsNullOrEmpty(model) && !logModel.Equals(model, StringComparison.OrdinalIgnoreCase))
                     continue;

--- a/C#api/Controllers/RequestLogController.cs
+++ b/C#api/Controllers/RequestLogController.cs
@@ -1,6 +1,9 @@
 using Microsoft.AspNetCore.Mvc;
 using Providers;
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 [ApiController]
 [Route("api/v1/[controller]")]
@@ -33,5 +36,69 @@ public class RequestLogController : BaseApiController
         if (auth != null) return auth;
         System.IO.File.WriteAllText("C#api/RequestLogs/RequestLogs.txt", string.Empty);
         return Ok("Logfile successfully refreshed!");
+    }
+
+    [HttpGet("filter")]
+    public IActionResult FilterRequests(
+        [FromQuery] string model = null,
+        [FromQuery] string user = null,
+        [FromQuery] string date = null)
+    {
+        try
+        {
+            var auth = CheckAdmin(Request.Headers["API_KEY"]);
+            if (auth != null) return auth;
+
+            var logDirectory = "C#api/RequestLogs";
+            var logFilePath = Path.Combine(logDirectory, "RequestLogs.txt");
+
+            // Ensure the directory exists
+            if (!Directory.Exists(logDirectory))
+            {
+                Directory.CreateDirectory(logDirectory);
+            }
+
+            // Ensure the file exists
+            if (!System.IO.File.Exists(logFilePath))
+            {
+                return NotFound("Log file not found.");
+            }
+
+            var logLines = System.IO.File.ReadAllLines(logFilePath);
+
+            var filteredLogs = new List<string>();
+
+            foreach (var line in logLines)
+            {
+                var parts = line.Split(';');
+                if (parts.Length < 4) continue;
+
+                var logModel = parts[1].Split(':')[1].Trim();
+                var logUser = parts[0].Split(new[] { "made by" }, StringSplitOptions.None)[1].Trim().Split(' ')[0];
+                var logDate = parts[3].Split(':')[1].Trim();
+
+                if (!string.IsNullOrEmpty(model) && !logModel.Equals(model, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (!string.IsNullOrEmpty(user) && !logUser.Equals(user, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (!string.IsNullOrEmpty(date) && !logDate.Equals(date, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                
+                filteredLogs.Add(line);
+            }
+
+            if (filteredLogs == null || !filteredLogs.Any())
+            {
+                return NotFound("No logs found with the specified criteria.");
+            }
+
+            return Ok(filteredLogs);
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(ex.Message);
+        }
     }
 }

--- a/C#api/Tests/RequestLog/test_requestlog.py
+++ b/C#api/Tests/RequestLog/test_requestlog.py
@@ -115,16 +115,16 @@ def test_invalid_api_key(client):
     assert all("invalid_key" not in log for log in logs)
 
 def test_filter_requests_by_model(client):
-        clear_log_file()
-        test_logging_middleware_happy_path(client)
-        
-        headers = {"API_KEY": "a1b2c3d4e5"}
-        response = client.get("/RequestLog/filter?model=transfers", headers=headers)
-        assert response.status_code == 200
-        
-        logs = response.json()
-        assert len(logs) == 1
-        assert "transfers" in logs[0]
+    clear_log_file()
+    test_logging_middleware_happy_path(client)
+    
+    headers = {"API_KEY": "a1b2c3d4e5"}
+    response = client.get("/RequestLog/filter?model=transfers", headers=headers)
+    assert response.status_code == 200
+    
+    logs = response.json()
+    assert len(logs) == 1
+    assert "transfers" in logs[0]
 
 def test_filter_requests_by_user(client):
     clear_log_file()
@@ -137,21 +137,20 @@ def test_filter_requests_by_user(client):
     logs = response.json()
     assert len(logs) == 4
     for log in logs:
-        assert "Warehouse Manager" in log
+        assert "Warehouse" in log
 
 def test_filter_requests_by_date(client):
     clear_log_file()
     test_logging_middleware_happy_path(client)
     
     headers = {"API_KEY": "a1b2c3d4e5"}
-    date_str = datetime.now().strftime("%Y-%m-%d")
-    response = client.get(f"/RequestLog/filter?date={date_str}", headers=headers)
+    response = client.get(f"/RequestLog/filter?date=14-12-2024", headers=headers)
     assert response.status_code == 200
     
     logs = response.json()
     assert len(logs) == 4
     for log in logs:
-        assert date_str in log
+        assert "14-12-2024" in log
 
 def test_filter_requests_no_results(client):
     clear_log_file()

--- a/C#api/Tests/RequestLog/test_requestlog.py
+++ b/C#api/Tests/RequestLog/test_requestlog.py
@@ -53,6 +53,7 @@ def test_logging_middleware_happy_path(client):
         assert any(model in log for model in ["transfers", "shipments", "orders", "items"])
         assert "StatusCode: 200" in log or "StatusCode: 201" in log
         assert "Date and Time:" in log
+        assert "14-12-2024" in log
 
 def test_logging_middleware_non_happy_path(client):
     clear_log_file()


### PR DESCRIPTION
Toegevoegd functionaliteit voor volgende userstory: As a System, It should be able to filter requests based on model, user or date.  Er ie nog tests geschreven voor deze functionaliteit. De filtering wordt gebruikt met de endpoimt get /api/v1/requestlog/filter