### PR TITLE
Unittests Model Mapping

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -62,11 +62,10 @@ jobs:
           ${{ runner.os }}-dotnet-
     - name: Build the application
       run: dotnet build --configuration Release
-    - name: Run unit tests
-      run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage" --results-directory ./coverage
-    - name: Generate unit test coverage report
+    - name: Run unit tests with coverage
+      run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage" --results-directory ./coverage --verbosity normal
+    - name: Generate coverage reports
       run: |
-        # Check if reportgenerator is available
         if ! command -v reportgenerator &> /dev/null; then
           echo "Installing ReportGenerator..."
           dotnet tool install --tool-path /tmp/tools dotnet-reportgenerator-globaltool
@@ -75,7 +74,19 @@ jobs:
           echo "ReportGenerator already installed, skipping installation"
         fi
         
-        reportgenerator -reports:"./coverage/**/coverage.cobertura.xml" -targetdir:"coveragereport" -reporttypes:Html
+        reportgenerator \
+          -reports:"./coverage/**/coverage.cobertura.xml" \
+          -targetdir:"coveragereport" \
+          -reporttypes:"Html;Cobertura;JsonSummary"
+
+    - name: Upload Coverage Reports
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-reports
+        path: |
+          ./coverage/**/coverage.cobertura.xml
+          ./coveragereport/**
+        retention-days: 7
     - name: Calculate unit test coverage percentage
       id: unit-test-coverage
       run: |

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -65,9 +65,13 @@ jobs:
     - name: Run unit tests
       run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage" --results-directory ./coverage
     - name: Install ReportGenerator
-      run: dotnet tool install -g dotnet-reportgenerator-globaltool
+      run: |
+        dotnet tool install -g dotnet-reportgenerator-globaltool
+        echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
     - name: Generate unit test coverage report
-      run: reportgenerator -reports:"./coverage/**/coverage.cobertura.xml" -targetdir:"coveragereport" -reporttypes:Html
+      run: |
+        export PATH="$PATH:$HOME/.dotnet/tools"
+        reportgenerator -reports:"./coverage/**/coverage.cobertura.xml" -targetdir:"coveragereport" -reporttypes:Html
     - name: Calculate unit test coverage percentage
       id: unit-test-coverage
       run: |

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -66,6 +66,7 @@ jobs:
       run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage" --results-directory ./coverage
     - name: Install ReportGenerator
       run: |
+        dotnet tool uninstall -g dotnet-reportgenerator-globaltool || true
         dotnet tool install -g dotnet-reportgenerator-globaltool
         echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
     - name: Generate unit test coverage report

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -46,6 +46,7 @@ jobs:
     outputs:
       TEST_TIME: ${{ steps.test-time.outputs.time }}
       COVERAGE: ${{ steps.coverage.outputs.percentage }}
+      UNIT_TEST_COVERAGE: ${{ steps.unit-test-coverage.outputs.percentage }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET Core
@@ -61,6 +62,17 @@ jobs:
           ${{ runner.os }}-dotnet-
     - name: Build the application
       run: dotnet build --configuration Release
+    - name: Run unit tests
+      run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage" --results-directory ./coverage
+    - name: Install ReportGenerator
+      run: dotnet tool install -g dotnet-reportgenerator-globaltool
+    - name: Generate unit test coverage report
+      run: reportgenerator -reports:"./coverage/**/coverage.cobertura.xml" -targetdir:"coveragereport" -reporttypes:Html
+    - name: Calculate unit test coverage percentage
+      id: unit-test-coverage
+      run: |
+        COVERAGE=$(grep -oP '(?<=Line coverage:).*?(?=%)' coveragereport/index.htm)
+        echo "percentage=$COVERAGE" >> $GITHUB_OUTPUT
     - name: Run application
       run: dotnet run --no-build --configuration Release --urls=${{ secrets.LOCALHOST }} & sleep 5
     - name: Setup Python
@@ -132,6 +144,7 @@ jobs:
           coverage-summary.txt
           parsed-coverage-summary.txt
           coverage.xml
+          coveragereport/**
         retention-days: 1
     - name: Set test Completion time
       id: test-time

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -64,21 +64,6 @@ jobs:
       run: dotnet build --configuration Release
     - name: Run unit tests with coverage
       run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage" --results-directory ./coverage --verbosity normal
-    - name: Generate coverage reports
-      run: |
-        if ! command -v reportgenerator &> /dev/null; then
-          echo "Installing ReportGenerator..."
-          dotnet tool install --tool-path /tmp/tools dotnet-reportgenerator-globaltool
-          export PATH="$PATH:/tmp/tools"
-        else
-          echo "ReportGenerator already installed, skipping installation"
-        fi
-        
-        reportgenerator \
-          -reports:"./coverage/**/coverage.cobertura.xml" \
-          -targetdir:"coveragereport" \
-          -reporttypes:"Html;Cobertura;JsonSummary"
-
     - name: Upload Coverage Reports
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -64,14 +64,17 @@ jobs:
       run: dotnet build --configuration Release
     - name: Run unit tests
       run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage" --results-directory ./coverage
-    - name: Install ReportGenerator
-      run: |
-        dotnet tool uninstall -g dotnet-reportgenerator-globaltool || true
-        dotnet tool install -g dotnet-reportgenerator-globaltool
-        echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
     - name: Generate unit test coverage report
       run: |
-        export PATH="$PATH:$HOME/.dotnet/tools"
+        # Check if reportgenerator is available
+        if ! command -v reportgenerator &> /dev/null; then
+          echo "Installing ReportGenerator..."
+          dotnet tool install --tool-path /tmp/tools dotnet-reportgenerator-globaltool
+          export PATH="$PATH:/tmp/tools"
+        else
+          echo "ReportGenerator already installed, skipping installation"
+        fi
+        
         reportgenerator -reports:"./coverage/**/coverage.cobertura.xml" -targetdir:"coveragereport" -reporttypes:Html
     - name: Calculate unit test coverage percentage
       id: unit-test-coverage

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -64,19 +64,6 @@ jobs:
       run: dotnet build --configuration Release
     - name: Run unit tests with coverage
       run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage" --results-directory ./coverage --verbosity normal
-    - name: Upload Coverage Reports
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage-reports
-        path: |
-          ./coverage/**/coverage.cobertura.xml
-          ./coveragereport/**
-        retention-days: 7
-    - name: Calculate unit test coverage percentage
-      id: unit-test-coverage
-      run: |
-        COVERAGE=$(grep -oP '(?<=Line coverage:).*?(?=%)' coveragereport/index.htm)
-        echo "percentage=$COVERAGE" >> $GITHUB_OUTPUT
     - name: Run application
       run: dotnet run --no-build --configuration Release --urls=${{ secrets.LOCALHOST }} & sleep 5
     - name: Setup Python

--- a/C#api/Tests/Unittests/ClientModelMappingTest.cs
+++ b/C#api/Tests/Unittests/ClientModelMappingTest.cs
@@ -1,0 +1,110 @@
+using System;
+using Newtonsoft.Json;
+using Xunit;
+using Models;
+
+public class ClientModelTests
+{
+    [Fact]
+    public void Deserialize_ValidJson_ReturnsClientObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Name"": ""Test Client"",
+            ""Address"": ""456 Client St"",
+            ""City"": ""Client City"",
+            ""Zip_code"": ""54321"",
+            ""Province"": ""Client Province"",
+            ""Country"": ""Client Country"",
+            ""Contact_name"": ""Jane Smith"",
+            ""Contact_phone"": ""987-654-3210"",
+            ""Contact_email"": ""jane@example.com"",
+            ""Created_at"": ""2023-01-01T00:00:00Z"",
+            ""Updated_at"": ""2023-01-02T00:00:00Z""
+        }";
+
+        // Act
+        var client = JsonConvert.DeserializeObject<Client>(json);
+
+        // Assert
+        Assert.NotNull(client);
+        Assert.Equal(1, client.Id);
+        Assert.Equal("Test Client", client.Name);
+        Assert.Equal("456 Client St", client.Address);
+        Assert.Equal("Client City", client.City);
+        Assert.Equal("54321", client.Zip_code);
+        Assert.Equal("Client Province", client.Province);
+        Assert.Equal("Client Country", client.Country);
+        Assert.Equal("Jane Smith", client.Contact_name);
+        Assert.Equal("987-654-3210", client.Contact_phone);
+        Assert.Equal("jane@example.com", client.Contact_email);
+        Assert.Equal("2023-01-01T00:00:00Z", client.Created_at);
+        Assert.Equal("2023-01-02T00:00:00Z", client.Updated_at);
+    }
+
+    [Fact]
+    public void Deserialize_MissingOptionalFields_ReturnsClientObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Name"": ""Test Client"",
+            ""Address"": ""456 Client St"",
+            ""City"": ""Client City"",
+            ""Zip_code"": ""54321"",
+            ""Country"": ""Client Country"",
+            ""Contact_name"": ""Jane Smith"",
+            ""Contact_phone"": ""987-654-3210""
+        }";
+
+        // Act
+        var client = JsonConvert.DeserializeObject<Client>(json);
+
+        // Assert
+        Assert.NotNull(client);
+        Assert.Null(client.Id);
+        Assert.Null(client.Province);
+        Assert.Null(client.Contact_email);
+        Assert.Null(client.Created_at);
+        Assert.Null(client.Updated_at);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidJson_ThrowsJsonException()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": ""Not a number"",
+            ""Name"": 12345,
+            ""Invalid_Field"": ""This field doesn't exist""
+        }";
+
+        // Act & Assert
+        Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<Client>(json));
+    }
+
+    [Fact]
+    public void Deserialize_MissingRequiredFields_ReturnsIncompleteObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Name"": ""Test Client""
+        }";
+
+        // Act
+        var client = JsonConvert.DeserializeObject<Client>(json);
+
+        // Assert
+        Assert.NotNull(client);
+        Assert.Equal(1, client.Id);
+        Assert.Equal("Test Client", client.Name);
+        Assert.Null(client.Address);
+        Assert.Null(client.City);
+        Assert.Null(client.Zip_code);
+        Assert.Null(client.Country);
+        Assert.Null(client.Contact_name);
+        Assert.Null(client.Contact_phone);
+    }
+}
+

--- a/C#api/Tests/Unittests/ItemGroupModelTest.cs
+++ b/C#api/Tests/Unittests/ItemGroupModelTest.cs
@@ -1,0 +1,83 @@
+using System;
+using Newtonsoft.Json;
+using Xunit;
+using Models;
+
+public class ItemGroupModelTests
+{
+    [Fact]
+    public void Deserialize_ValidJson_ReturnsItemGroupObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Name"": ""Test Item Group"",
+            ""Description"": ""This is a test item group"",
+            ""Created_At"": ""2023-01-01T00:00:00Z"",
+            ""Updated_At"": ""2023-01-02T00:00:00Z""
+        }";
+
+        // Act
+        var itemGroup = JsonConvert.DeserializeObject<ItemGroup>(json);
+
+        // Assert
+        Assert.NotNull(itemGroup);
+        Assert.Equal(1, itemGroup.Id);
+        Assert.Equal("Test Item Group", itemGroup.Name);
+        Assert.Equal("This is a test item group", itemGroup.Description);
+        Assert.Equal("2023-01-01T00:00:00Z", itemGroup.Created_At);
+        Assert.Equal("2023-01-02T00:00:00Z", itemGroup.Updated_At);
+    }
+
+    [Fact]
+    public void Deserialize_MissingOptionalFields_ReturnsItemGroupObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Name"": ""Test Item Group"",
+            ""Description"": ""This is a test item group""
+        }";
+
+        // Act
+        var itemGroup = JsonConvert.DeserializeObject<ItemGroup>(json);
+
+        // Assert
+        Assert.NotNull(itemGroup);
+        Assert.Null(itemGroup.Id);
+        Assert.Null(itemGroup.Created_At);
+        Assert.Null(itemGroup.Updated_At);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidJson_ThrowsJsonException()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": ""Not a number"",
+            ""Name"": 12345,
+            ""Invalid_Field"": ""This field doesn't exist""
+        }";
+
+        // Act & Assert
+        Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<ItemGroup>(json));
+    }
+
+    [Fact]
+    public void Deserialize_MissingRequiredFields_ReturnsIncompleteObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1
+        }";
+
+        // Act
+        var itemGroup = JsonConvert.DeserializeObject<ItemGroup>(json);
+
+        // Assert
+        Assert.NotNull(itemGroup);
+        Assert.Equal(1, itemGroup.Id);
+        Assert.Null(itemGroup.Name);
+        Assert.Null(itemGroup.Description);
+    }
+}
+

--- a/C#api/Tests/Unittests/ItemLineModelTest.cs
+++ b/C#api/Tests/Unittests/ItemLineModelTest.cs
@@ -1,0 +1,83 @@
+using System;
+using Newtonsoft.Json;
+using Xunit;
+using Models;
+
+public class ItemLineModelTests
+{
+    [Fact]
+    public void Deserialize_ValidJson_ReturnsItemLineObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Name"": ""Test Item Line"",
+            ""Description"": ""This is a test item line"",
+            ""Created_At"": ""2023-01-01T00:00:00Z"",
+            ""Updated_At"": ""2023-01-02T00:00:00Z""
+        }";
+
+        // Act
+        var itemLine = JsonConvert.DeserializeObject<ItemLine>(json);
+
+        // Assert
+        Assert.NotNull(itemLine);
+        Assert.Equal(1, itemLine.Id);
+        Assert.Equal("Test Item Line", itemLine.Name);
+        Assert.Equal("This is a test item line", itemLine.Description);
+        Assert.Equal("2023-01-01T00:00:00Z", itemLine.Created_At);
+        Assert.Equal("2023-01-02T00:00:00Z", itemLine.Updated_At);
+    }
+
+    [Fact]
+    public void Deserialize_MissingOptionalFields_ReturnsItemLineObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Name"": ""Test Item Line"",
+            ""Description"": ""This is a test item line""
+        }";
+
+        // Act
+        var itemLine = JsonConvert.DeserializeObject<ItemLine>(json);
+
+        // Assert
+        Assert.NotNull(itemLine);
+        Assert.Null(itemLine.Id);
+        Assert.Null(itemLine.Created_At);
+        Assert.Null(itemLine.Updated_At);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidJson_ThrowsJsonException()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": ""Not a number"",
+            ""Name"": 12345,
+            ""Invalid_Field"": ""This field doesn't exist""
+        }";
+
+        // Act & Assert
+        Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<ItemLine>(json));
+    }
+
+    [Fact]
+    public void Deserialize_MissingRequiredFields_ReturnsIncompleteObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1
+        }";
+
+        // Act
+        var itemLine = JsonConvert.DeserializeObject<ItemLine>(json);
+
+        // Assert
+        Assert.NotNull(itemLine);
+        Assert.Equal(1, itemLine.Id);
+        Assert.Null(itemLine.Name);
+        Assert.Null(itemLine.Description);
+    }
+}
+

--- a/C#api/Tests/Unittests/ItemModelTest.cs
+++ b/C#api/Tests/Unittests/ItemModelTest.cs
@@ -1,0 +1,127 @@
+using System;
+using Newtonsoft.Json;
+using Xunit;
+using Models;
+
+public class ItemModelTests
+{
+    [Fact]
+    public void Deserialize_ValidJson_ReturnsItemObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Uid"": ""ITEM001"",
+            ""Code"": ""CODE001"",
+            ""Description"": ""Test Item"",
+            ""Short_Description"": ""Test"",
+            ""Upc_Code"": ""123456789012"",
+            ""Model_Number"": ""MODEL001"",
+            ""Commodity_Code"": ""COMM001"",
+            ""Item_Line"": 1,
+            ""Item_Group"": 2,
+            ""Item_Type"": 3,
+            ""Unit_Purchase_Quantity"": 10,
+            ""Unit_Order_Quantity"": 5,
+            ""Pack_Order_Quantity"": 50,
+            ""Supplier_Id"": 100,
+            ""Supplier_Code"": ""SUP001"",
+            ""Supplier_Part_Number"": ""PART001"",
+            ""Created_At"": ""2023-01-01T00:00:00Z"",
+            ""Updated_At"": ""2023-01-02T00:00:00Z""
+        }";
+
+        // Act
+        var item = JsonConvert.DeserializeObject<Item>(json);
+
+        // Assert
+        Assert.NotNull(item);
+        Assert.Equal("ITEM001", item.Uid);
+        Assert.Equal("CODE001", item.Code);
+        Assert.Equal("Test Item", item.Description);
+        Assert.Equal("Test", item.Short_Description);
+        Assert.Equal("123456789012", item.Upc_Code);
+        Assert.Equal("MODEL001", item.Model_Number);
+        Assert.Equal("COMM001", item.Commodity_Code);
+        Assert.Equal(1, item.Item_Line);
+        Assert.Equal(2, item.Item_Group);
+        Assert.Equal(3, item.Item_Type);
+        Assert.Equal(10, item.Unit_Purchase_Quantity);
+        Assert.Equal(5, item.Unit_Order_Quantity);
+        Assert.Equal(50, item.Pack_Order_Quantity);
+        Assert.Equal(100, item.Supplier_Id);
+        Assert.Equal("SUP001", item.Supplier_Code);
+        Assert.Equal("PART001", item.Supplier_Part_Number);
+        Assert.Equal("2023-01-01T00:00:00Z", item.Created_At);
+        Assert.Equal("2023-01-02T00:00:00Z", item.Updated_At);
+    }
+
+    [Fact]
+    public void Deserialize_MissingOptionalFields_ReturnsItemObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Code"": ""CODE001"",
+            ""Description"": ""Test Item"",
+            ""Item_Line"": 1,
+            ""Item_Group"": 2,
+            ""Item_Type"": 3,
+            ""Supplier_Id"": 100
+        }";
+
+        // Act
+        var item = JsonConvert.DeserializeObject<Item>(json);
+
+        // Assert
+        Assert.NotNull(item);
+        Assert.Null(item.Uid);
+        Assert.Null(item.Short_Description);
+        Assert.Null(item.Upc_Code);
+        Assert.Null(item.Model_Number);
+        Assert.Null(item.Commodity_Code);
+        Assert.Equal(0, item.Unit_Purchase_Quantity);
+        Assert.Equal(0, item.Unit_Order_Quantity);
+        Assert.Equal(0, item.Pack_Order_Quantity);
+        Assert.Null(item.Supplier_Code);
+        Assert.Null(item.Supplier_Part_Number);
+        Assert.Null(item.Created_At);
+        Assert.Null(item.Updated_At);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidJson_ThrowsJsonException()
+    {
+        // Arrange
+        string json = @"{
+            ""Uid"": 12345,
+            ""Item_Line"": ""Not a number"",
+            ""Invalid_Field"": ""This field doesn't exist""
+        }";
+
+        // Act & Assert
+        Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<Item>(json));
+    }
+
+    [Fact]
+    public void Deserialize_MissingRequiredFields_ReturnsIncompleteObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Uid"": ""ITEM001"",
+            ""Code"": ""CODE001""
+        }";
+
+        // Act
+        var item = JsonConvert.DeserializeObject<Item>(json);
+
+        // Assert
+        Assert.NotNull(item);
+        Assert.Equal("ITEM001", item.Uid);
+        Assert.Equal("CODE001", item.Code);
+        Assert.Null(item.Description);
+        Assert.Equal(0, item.Item_Line);
+        Assert.Equal(0, item.Item_Group);
+        Assert.Equal(0, item.Item_Type);
+        Assert.Equal(0, item.Supplier_Id);
+    }
+}
+

--- a/C#api/Tests/Unittests/ItemTypeModelTest.cs
+++ b/C#api/Tests/Unittests/ItemTypeModelTest.cs
@@ -1,0 +1,83 @@
+using System;
+using Newtonsoft.Json;
+using Xunit;
+using Models;
+
+public class ItemTypeModelTests
+{
+    [Fact]
+    public void Deserialize_ValidJson_ReturnsItemTypeObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Name"": ""Test Item Type"",
+            ""Description"": ""This is a test item type"",
+            ""Created_At"": ""2023-01-01T00:00:00Z"",
+            ""Updated_At"": ""2023-01-02T00:00:00Z""
+        }";
+
+        // Act
+        var itemType = JsonConvert.DeserializeObject<ItemType>(json);
+
+        // Assert
+        Assert.NotNull(itemType);
+        Assert.Equal(1, itemType.Id);
+        Assert.Equal("Test Item Type", itemType.Name);
+        Assert.Equal("This is a test item type", itemType.Description);
+        Assert.Equal("2023-01-01T00:00:00Z", itemType.Created_At);
+        Assert.Equal("2023-01-02T00:00:00Z", itemType.Updated_At);
+    }
+
+    [Fact]
+    public void Deserialize_MissingOptionalFields_ReturnsItemTypeObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Name"": ""Test Item Type"",
+            ""Description"": ""This is a test item type""
+        }";
+
+        // Act
+        var itemType = JsonConvert.DeserializeObject<ItemType>(json);
+
+        // Assert
+        Assert.NotNull(itemType);
+        Assert.Null(itemType.Id);
+        Assert.Null(itemType.Created_At);
+        Assert.Null(itemType.Updated_At);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidJson_ThrowsJsonException()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": ""Not a number"",
+            ""Name"": 12345,
+            ""Invalid_Field"": ""This field doesn't exist""
+        }";
+
+        // Act & Assert
+        Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<ItemType>(json));
+    }
+
+    [Fact]
+    public void Deserialize_MissingRequiredFields_ReturnsIncompleteObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1
+        }";
+
+        // Act
+        var itemType = JsonConvert.DeserializeObject<ItemType>(json);
+
+        // Assert
+        Assert.NotNull(itemType);
+        Assert.Equal(1, itemType.Id);
+        Assert.Null(itemType.Name);
+        Assert.Null(itemType.Description);
+    }
+}
+

--- a/C#api/Tests/Unittests/LocationModelTest.cs
+++ b/C#api/Tests/Unittests/LocationModelTest.cs
@@ -1,0 +1,88 @@
+using System;
+using Newtonsoft.Json;
+using Xunit;
+using Models;
+
+public class LocationModelTests
+{
+    [Fact]
+    public void Deserialize_ValidJson_ReturnsLocationObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Warehouse_Id"": 100,
+            ""Code"": ""LOC001"",
+            ""Name"": ""Test Location"",
+            ""Created_At"": ""2023-01-01T00:00:00Z"",
+            ""Updated_At"": ""2023-01-02T00:00:00Z""
+        }";
+
+        // Act
+        var location = JsonConvert.DeserializeObject<Location>(json);
+
+        // Assert
+        Assert.NotNull(location);
+        Assert.Equal(1, location.Id);
+        Assert.Equal(100, location.Warehouse_Id);
+        Assert.Equal("LOC001", location.Code);
+        Assert.Equal("Test Location", location.Name);
+        Assert.Equal("2023-01-01T00:00:00Z", location.Created_At);
+        Assert.Equal("2023-01-02T00:00:00Z", location.Updated_At);
+    }
+
+    [Fact]
+    public void Deserialize_MissingOptionalFields_ReturnsLocationObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Warehouse_Id"": 100,
+            ""Code"": ""LOC001"",
+            ""Name"": ""Test Location""
+        }";
+
+        // Act
+        var location = JsonConvert.DeserializeObject<Location>(json);
+
+        // Assert
+        Assert.NotNull(location);
+        Assert.Null(location.Id);
+        Assert.Null(location.Created_At);
+        Assert.Null(location.Updated_At);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidJson_ThrowsJsonException()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": ""Not a number"",
+            ""Warehouse_Id"": ""Also not a number"",
+            ""Invalid_Field"": ""This field doesn't exist""
+        }";
+
+        // Act & Assert
+        Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<Location>(json));
+    }
+
+    [Fact]
+    public void Deserialize_MissingRequiredFields_ReturnsIncompleteObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Warehouse_Id"": 100
+        }";
+
+        // Act
+        var location = JsonConvert.DeserializeObject<Location>(json);
+
+        // Assert
+        Assert.NotNull(location);
+        Assert.Equal(1, location.Id);
+        Assert.Equal(100, location.Warehouse_Id);
+        Assert.Null(location.Code);
+        Assert.Null(location.Name);
+    }
+}
+

--- a/C#api/Tests/Unittests/OrderModelTest.cs
+++ b/C#api/Tests/Unittests/OrderModelTest.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Xunit;
+using Models;
+
+public class OrderModelTests
+{
+    [Fact]
+    public void Deserialize_ValidJson_ReturnsOrderObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Source_Id"": 100,
+            ""Order_Date"": ""2023-01-01"",
+            ""Request_Date"": ""2023-01-10"",
+            ""Reference"": ""ORD001"",
+            ""Reference_Extra"": ""Extra info"",
+            ""Order_Status"": ""Pending"",
+            ""Notes"": ""Test order"",
+            ""Shipping_Notes"": ""Handle with care"",
+            ""Picking_Notes"": ""Pick from aisle 5"",
+            ""Warehouse_Id"": 1,
+            ""Ship_To"": 1000,
+            ""Bill_To"": 1001,
+            ""Shipment_Id"": 500,
+            ""Total_Amount"": 1000.50,
+            ""Total_Discount"": 50.25,
+            ""Total_Tax"": 75.50,
+            ""Total_Surcharge"": 10.00,
+            ""Created_At"": ""2023-01-01T00:00:00Z"",
+            ""Updated_At"": ""2023-01-02T00:00:00Z"",
+            ""Items"": [
+                {
+                    ""Item_Id"": ""ITEM001"",
+                    ""Amount"": 5
+                },
+                {
+                    ""Item_Id"": ""ITEM002"",
+                    ""Amount"": 3
+                }
+            ]
+        }";
+
+        // Act
+        var order = JsonConvert.DeserializeObject<Order>(json);
+
+        // Assert
+        Assert.NotNull(order);
+        Assert.Equal(1, order.Id);
+        Assert.Equal(100, order.Source_Id);
+        Assert.Equal("2023-01-01", order.Order_Date);
+        Assert.Equal("2023-01-10", order.Request_Date);
+        Assert.Equal("ORD001", order.Reference);
+        Assert.Equal("Extra info", order.Reference_Extra);
+        Assert.Equal("Pending", order.Order_Status);
+        Assert.Equal("Test order", order.Notes);
+        Assert.Equal("Handle with care", order.Shipping_Notes);
+        Assert.Equal("Pick from aisle 5", order.Picking_Notes);
+        Assert.Equal(1, order.Warehouse_Id);
+        Assert.Equal(1000, order.Ship_To);
+        Assert.Equal(1001, order.Bill_To);
+        Assert.Equal(500, order.Shipment_Id);
+        Assert.Equal(1000.50m, order.Total_Amount);
+        Assert.Equal(50.25m, order.Total_Discount);
+        Assert.Equal(75.50m, order.Total_Tax);
+        Assert.Equal(10.00m, order.Total_Surcharge);
+        Assert.Equal("2023-01-01T00:00:00Z", order.Created_At);
+        Assert.Equal("2023-01-02T00:00:00Z", order.Updated_At);
+        Assert.NotNull(order.Items);
+        Assert.Equal(2, order.Items.Count);
+        Assert.Equal("ITEM001", order.Items[0].Item_Id);
+        Assert.Equal(5, order.Items[0].Amount);
+        Assert.Equal("ITEM002", order.Items[1].Item_Id);
+        Assert.Equal(3, order.Items[1].Amount);
+    }
+
+    [Fact]
+    public void Deserialize_MissingOptionalFields_ReturnsOrderObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Source_Id"": 100,
+            ""Order_Date"": ""2023-01-01"",
+            ""Request_Date"": ""2023-01-10"",
+            ""Reference"": ""ORD001"",
+            ""Warehouse_Id"": 1,
+            ""Total_Amount"": 1000.50,
+            ""Items"": []
+        }";
+
+        // Act
+        var order = JsonConvert.DeserializeObject<Order>(json);
+
+        // Assert
+        Assert.NotNull(order);
+        Assert.Null(order.Id);
+        Assert.Null(order.Order_Status);
+        Assert.Null(order.Ship_To);
+        Assert.Null(order.Bill_To);
+        Assert.Null(order.Shipment_Id);
+        Assert.Null(order.Created_At);
+        Assert.Null(order.Updated_At);
+        Assert.NotNull(order.Items);
+        Assert.Empty(order.Items);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidJson_ThrowsJsonException()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": ""Not a number"",
+            ""Source_Id"": ""Also not a number"",
+            ""Invalid_Field"": ""This field doesn't exist""
+        }";
+
+        // Act & Assert
+        Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<Order>(json));
+    }
+
+    [Fact]
+    public void Deserialize_MissingRequiredFields_ReturnsIncompleteObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Source_Id"": 100
+        }";
+
+        // Act
+        var order = JsonConvert.DeserializeObject<Order>(json);
+
+        // Assert
+        Assert.NotNull(order);
+        Assert.Equal(1, order.Id);
+        Assert.Equal(100, order.Source_Id);
+        Assert.Null(order.Order_Date);
+        Assert.Null(order.Request_Date);
+        Assert.Null(order.Reference);
+        Assert.Equal(0, order.Warehouse_Id);
+        Assert.Equal(0, order.Total_Amount);
+        Assert.Null(order.Items);
+    }
+}
+

--- a/C#api/Tests/Unittests/ShipmentModelTest.cs
+++ b/C#api/Tests/Unittests/ShipmentModelTest.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Xunit;
+using Models;
+
+public class ShipmentModelTests
+{
+    [Fact]
+    public void Deserialize_ValidJson_ReturnsShipmentObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Order_Id"": 100,
+            ""Source_Id"": 200,
+            ""Order_Date"": ""2023-01-01"",
+            ""Request_Date"": ""2023-01-10"",
+            ""Shipment_Date"": ""2023-01-15"",
+            ""Shipment_Type"": ""Express"",
+            ""Shipment_Status"": ""In Transit"",
+            ""Notes"": ""Handle with care"",
+            ""Carrier_Code"": ""CAR001"",
+            ""Carrier_Description"": ""Test Carrier"",
+            ""Service_Code"": ""SVC001"",
+            ""Payment_Type"": ""Prepaid"",
+            ""Transfer_Mode"": ""Air"",
+            ""Total_Package_Count"": 5,
+            ""Total_Package_Weight"": 25.5,
+            ""Created_At"": ""2023-01-01T00:00:00Z"",
+            ""Updated_At"": ""2023-01-02T00:00:00Z"",
+            ""Items"": [
+                {
+                    ""Item_Id"": ""ITEM001"",
+                    ""Amount"": 3
+                },
+                {
+                    ""Item_Id"": ""ITEM002"",
+                    ""Amount"": 2
+                }
+            ]
+        }";
+
+        // Act
+        var shipment = JsonConvert.DeserializeObject<Shipment>(json);
+
+        // Assert
+        Assert.NotNull(shipment);
+        Assert.Equal(1, shipment.Id);
+        Assert.Equal(100, shipment.Order_Id);
+        Assert.Equal(200, shipment.Source_Id);
+        Assert.Equal("2023-01-01", shipment.Order_Date);
+        Assert.Equal("2023-01-10", shipment.Request_Date);
+        Assert.Equal("2023-01-15", shipment.Shipment_Date);
+        Assert.Equal("Express", shipment.Shipment_Type);
+        Assert.Equal("In Transit", shipment.Shipment_Status);
+        Assert.Equal("Handle with care", shipment.Notes);
+        Assert.Equal("CAR001", shipment.Carrier_Code);
+        Assert.Equal("Test Carrier", shipment.Carrier_Description);
+        Assert.Equal("SVC001", shipment.Service_Code);
+        Assert.Equal("Prepaid", shipment.Payment_Type);
+        Assert.Equal("Air", shipment.Transfer_Mode);
+        Assert.Equal(5, shipment.Total_Package_Count);
+        Assert.Equal(25.5, shipment.Total_Package_Weight);
+        Assert.Equal("2023-01-01T00:00:00Z", shipment.Created_At);
+        Assert.Equal("2023-01-02T00:00:00Z", shipment.Updated_At);
+        Assert.NotNull(shipment.Items);
+        Assert.Equal(2, shipment.Items.Count);
+        Assert.Equal("ITEM001", shipment.Items[0].Item_Id);
+        Assert.Equal(3, shipment.Items[0].Amount);
+        Assert.Equal("ITEM002", shipment.Items[1].Item_Id);
+        Assert.Equal(2, shipment.Items[1].Amount);
+    }
+
+    [Fact]
+    public void Deserialize_MissingOptionalFields_ReturnsShipmentObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Order_Id"": 100,
+            ""Source_Id"": 200,
+            ""Order_Date"": ""2023-01-01"",
+            ""Request_Date"": ""2023-01-10"",
+            ""Shipment_Date"": ""2023-01-15"",
+            ""Shipment_Type"": ""Express"",
+            ""Total_Package_Count"": 5,
+            ""Total_Package_Weight"": 25.5,
+            ""Items"": []
+        }";
+
+        // Act
+        var shipment = JsonConvert.DeserializeObject<Shipment>(json);
+
+        // Assert
+        Assert.NotNull(shipment);
+        Assert.Null(shipment.Id);
+        Assert.Null(shipment.Shipment_Status);
+        Assert.Null(shipment.Notes);
+        Assert.Null(shipment.Carrier_Code);
+        Assert.Null(shipment.Carrier_Description);
+        Assert.Null(shipment.Service_Code);
+        Assert.Null(shipment.Payment_Type);
+        Assert.Null(shipment.Transfer_Mode);
+        Assert.Null(shipment.Created_At);
+        Assert.Null(shipment.Updated_At);
+        Assert.NotNull(shipment.Items);
+        Assert.Empty(shipment.Items);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidJson_ThrowsJsonException()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": ""Not a number"",
+            ""Order_Id"": ""Also not a number"",
+            ""Invalid_Field"": ""This field doesn't exist""
+        }";
+
+        // Act & Assert
+        Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<Shipment>(json));
+    }
+
+    [Fact]
+    public void Deserialize_MissingRequiredFields_ReturnsIncompleteObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Order_Id"": 100
+        }";
+
+        // Act
+        var shipment = JsonConvert.DeserializeObject<Shipment>(json);
+
+        // Assert
+        Assert.NotNull(shipment);
+        Assert.Equal(1, shipment.Id);
+        Assert.Equal(100, shipment.Order_Id);
+        Assert.Equal(0, shipment.Source_Id);
+        Assert.Null(shipment.Order_Date);
+        Assert.Null(shipment.Request_Date);
+        Assert.Null(shipment.Shipment_Date);
+        Assert.Null(shipment.Shipment_Type);
+        Assert.Equal(0, shipment.Total_Package_Count);
+        Assert.Equal(0, shipment.Total_Package_Weight);
+        Assert.Null(shipment.Items);
+    }
+}
+

--- a/C#api/Tests/Unittests/SupplierModelTest.cs
+++ b/C#api/Tests/Unittests/SupplierModelTest.cs
@@ -1,0 +1,117 @@
+using System;
+using Newtonsoft.Json;
+using Xunit;
+using Models;
+
+public class SupplierModelTests
+{
+    [Fact]
+    public void Deserialize_ValidJson_ReturnsSupplierObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Code"": ""SUP001"",
+            ""Name"": ""Test Supplier"",
+            ""Address"": ""123 Test St"",
+            ""Address_Extra"": ""Suite 100"",
+            ""City"": ""Test City"",
+            ""Zip_Code"": ""12345"",
+            ""Province"": ""Test Province"",
+            ""Country"": ""Test Country"",
+            ""Contact_Name"": ""John Doe"",
+            ""Phonenumber"": ""123-456-7890"",
+            ""Reference"": ""REF001"",
+            ""Created_At"": ""2023-01-01T00:00:00Z"",
+            ""Updated_At"": ""2023-01-02T00:00:00Z""
+        }";
+
+        // Act
+        var supplier = JsonConvert.DeserializeObject<Supplier>(json);
+
+        // Assert
+        Assert.NotNull(supplier);
+        Assert.Equal(1, supplier.Id);
+        Assert.Equal("SUP001", supplier.Code);
+        Assert.Equal("Test Supplier", supplier.Name);
+        Assert.Equal("123 Test St", supplier.Address);
+        Assert.Equal("Suite 100", supplier.Address_Extra);
+        Assert.Equal("Test City", supplier.City);
+        Assert.Equal("12345", supplier.Zip_Code);
+        Assert.Equal("Test Province", supplier.Province);
+        Assert.Equal("Test Country", supplier.Country);
+        Assert.Equal("John Doe", supplier.Contact_Name);
+        Assert.Equal("123-456-7890", supplier.Phonenumber);
+        Assert.Equal("REF001", supplier.Reference);
+        Assert.Equal("2023-01-01T00:00:00Z", supplier.Created_At);
+        Assert.Equal("2023-01-02T00:00:00Z", supplier.Updated_At);
+    }
+
+    [Fact]
+    public void Deserialize_MissingOptionalFields_ReturnsSupplierObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Code"": ""SUP001"",
+            ""Name"": ""Test Supplier"",
+            ""Address"": ""123 Test St"",
+            ""City"": ""Test City"",
+            ""Zip_Code"": ""12345"",
+            ""Country"": ""Test Country"",
+            ""Contact_Name"": ""John Doe"",
+            ""Phonenumber"": ""123-456-7890""
+        }";
+
+        // Act
+        var supplier = JsonConvert.DeserializeObject<Supplier>(json);
+
+        // Assert
+        Assert.NotNull(supplier);
+        Assert.Null(supplier.Id);
+        Assert.Null(supplier.Address_Extra);
+        Assert.Null(supplier.Province);
+        Assert.Null(supplier.Reference);
+        Assert.Null(supplier.Created_At);
+        Assert.Null(supplier.Updated_At);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidJson_ThrowsJsonException()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": ""Not a number"",
+            ""Code"": 12345,
+            ""Invalid_Field"": ""This field doesn't exist""
+        }";
+
+        // Act & Assert
+        Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<Supplier>(json));
+    }
+
+    [Fact]
+    public void Deserialize_MissingRequiredFields_ReturnsIncompleteObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Code"": ""SUP001""
+        }";
+
+        // Act
+        var supplier = JsonConvert.DeserializeObject<Supplier>(json);
+
+        // Assert
+        Assert.NotNull(supplier);
+        Assert.Equal(1, supplier.Id);
+        Assert.Equal("SUP001", supplier.Code);
+        Assert.Null(supplier.Name);
+        Assert.Null(supplier.Address);
+        Assert.Null(supplier.City);
+        Assert.Null(supplier.Zip_Code);
+        Assert.Null(supplier.Country);
+        Assert.Null(supplier.Contact_Name);
+        Assert.Null(supplier.Phonenumber);
+    }
+}
+

--- a/C#api/Tests/Unittests/TransferModelTest.cs
+++ b/C#api/Tests/Unittests/TransferModelTest.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Xunit;
+using Models;
+
+public class TransferModelTests
+{
+    [Fact]
+    public void Deserialize_ValidJson_ReturnsTransferObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Reference"": ""TRF001"",
+            ""Transfer_From"": 100,
+            ""Transfer_To"": 200,
+            ""Transfer_Status"": ""In Progress"",
+            ""Created_At"": ""2023-01-01T00:00:00Z"",
+            ""Updated_At"": ""2023-01-02T00:00:00Z"",
+            ""Items"": [
+                {
+                    ""Item_Id"": ""ITEM001"",
+                    ""Amount"": 5
+                },
+                {
+                    ""Item_Id"": ""ITEM002"",
+                    ""Amount"": 3
+                }
+            ]
+        }";
+
+        // Act
+        var transfer = JsonConvert.DeserializeObject<Transfer>(json);
+
+        // Assert
+        Assert.NotNull(transfer);
+        Assert.Equal(1, transfer.Id);
+        Assert.Equal("TRF001", transfer.Reference);
+        Assert.Equal(100, transfer.Transfer_From);
+        Assert.Equal(200, transfer.Transfer_To);
+        Assert.Equal("In Progress", transfer.Transfer_Status);
+        Assert.Equal("2023-01-01T00:00:00Z", transfer.Created_At);
+        Assert.Equal("2023-01-02T00:00:00Z", transfer.Updated_At);
+        Assert.NotNull(transfer.Items);
+        Assert.Equal(2, transfer.Items.Count);
+        Assert.Equal("ITEM001", transfer.Items[0].Item_Id);
+        Assert.Equal(5, transfer.Items[0].Amount);
+        Assert.Equal("ITEM002", transfer.Items[1].Item_Id);
+        Assert.Equal(3, transfer.Items[1].Amount);
+    }
+
+    [Fact]
+    public void Deserialize_MissingOptionalFields_ReturnsTransferObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Reference"": ""TRF001"",
+            ""Transfer_From"": 100,
+            ""Transfer_To"": 200,
+            ""Transfer_Status"": ""In Progress"",
+            ""Items"": []
+        }";
+
+        // Act
+        var transfer = JsonConvert.DeserializeObject<Transfer>(json);
+
+        // Assert
+        Assert.NotNull(transfer);
+        Assert.Null(transfer.Id);
+        Assert.Null(transfer.Created_At);
+        Assert.Null(transfer.Updated_At);
+        Assert.NotNull(transfer.Items);
+        Assert.Empty(transfer.Items);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidJson_ThrowsJsonException()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": ""Not a number"",
+            ""Transfer_From"": ""Also not a number"",
+            ""Invalid_Field"": ""This field doesn't exist""
+        }";
+
+        // Act & Assert
+        Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<Transfer>(json));
+    }
+
+    [Fact]
+    public void Deserialize_MissingRequiredFields_ReturnsIncompleteObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Reference"": ""TRF001""
+        }";
+
+        // Act
+        var transfer = JsonConvert.DeserializeObject<Transfer>(json);
+
+        // Assert
+        Assert.NotNull(transfer);
+        Assert.Equal(1, transfer.Id);
+        Assert.Equal("TRF001", transfer.Reference);
+        Assert.Null(transfer.Transfer_From);
+        Assert.Null(transfer.Transfer_To);
+        Assert.Null(transfer.Transfer_Status);
+        Assert.Null(transfer.Items);
+    }
+}
+

--- a/C#api/Tests/Unittests/Unittests.csproj
+++ b/C#api/Tests/Unittests/Unittests.csproj
@@ -1,25 +1,32 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <RootNamespace>Software_Construction</RootNamespace>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Software-Construction.csproj" />
   </ItemGroup>
 
 </Project>

--- a/C#api/Tests/Unittests/WarehouseModelTest.cs
+++ b/C#api/Tests/Unittests/WarehouseModelTest.cs
@@ -1,0 +1,113 @@
+using System;
+using Newtonsoft.Json;
+using Xunit;
+using Models;
+
+public class WarehouseModelTests
+{
+    [Fact]
+    public void Deserialize_ValidJson_ReturnsWarehouseObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Code"": ""WH001"",
+            ""Name"": ""Test Warehouse"",
+            ""Address"": ""123 Test St"",
+            ""Zip"": ""12345"",
+            ""City"": ""Test City"",
+            ""Province"": ""Test Province"",
+            ""Country"": ""Test Country"",
+            ""Contact"": {
+                ""Name"": ""John Doe"",
+                ""Phone"": ""123-456-7890"",
+                ""Email"": ""john@example.com""
+            },
+            ""Created_At"": ""2023-01-01T00:00:00Z"",
+            ""Updated_At"": ""2023-01-02T00:00:00Z""
+        }";
+
+        // Act
+        var warehouse = JsonConvert.DeserializeObject<Warehouse>(json);
+
+        // Assert
+        Assert.NotNull(warehouse);
+        Assert.Equal(1, warehouse.Id);
+        Assert.Equal("WH001", warehouse.Code);
+        Assert.Equal("Test Warehouse", warehouse.Name);
+        Assert.Equal("123 Test St", warehouse.Address);
+        Assert.Equal("12345", warehouse.Zip);
+        Assert.Equal("Test City", warehouse.City);
+        Assert.Equal("Test Province", warehouse.Province);
+        Assert.Equal("Test Country", warehouse.Country);
+        Assert.NotNull(warehouse.Contact);
+        Assert.Equal("John Doe", warehouse.Contact.Name);
+        Assert.Equal("123-456-7890", warehouse.Contact.Phone);
+        Assert.Equal("john@example.com", warehouse.Contact.Email);
+        Assert.Equal("2023-01-01T00:00:00Z", warehouse.Created_At);
+        Assert.Equal("2023-01-02T00:00:00Z", warehouse.Updated_At);
+    }
+
+    [Fact]
+    public void Deserialize_MissingOptionalFields_ReturnsWarehouseObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Code"": ""WH001"",
+            ""Name"": ""Test Warehouse"",
+            ""Address"": ""123 Test St"",
+            ""Zip"": ""12345"",
+            ""City"": ""Test City"",
+            ""Country"": ""Test Country""
+        }";
+
+        // Act
+        var warehouse = JsonConvert.DeserializeObject<Warehouse>(json);
+
+        // Assert
+        Assert.NotNull(warehouse);
+        Assert.Null(warehouse.Id);
+        Assert.Null(warehouse.Province);
+        Assert.Null(warehouse.Contact);
+        Assert.Null(warehouse.Created_At);
+        Assert.Null(warehouse.Updated_At);
+    }
+
+    [Fact]
+    public void Deserialize_InvalidJson_ThrowsJsonException()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": ""Not a number"",
+            ""Code"": 12345,
+            ""Invalid_Field"": ""This field doesn't exist""
+        }";
+
+        // Act & Assert
+        Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<Warehouse>(json));
+    }
+
+    [Fact]
+    public void Deserialize_MissingRequiredFields_ReturnsIncompleteObject()
+    {
+        // Arrange
+        string json = @"{
+            ""Id"": 1,
+            ""Code"": ""WH001""
+        }";
+
+        // Act
+        var warehouse = JsonConvert.DeserializeObject<Warehouse>(json);
+
+        // Assert
+        Assert.NotNull(warehouse);
+        Assert.Equal(1, warehouse.Id);
+        Assert.Equal("WH001", warehouse.Code);
+        Assert.Null(warehouse.Name);
+        Assert.Null(warehouse.Address);
+        Assert.Null(warehouse.Zip);
+        Assert.Null(warehouse.City);
+        Assert.Null(warehouse.Country);
+    }
+}
+

--- a/Software-Construction.sln
+++ b/Software-Construction.sln
@@ -5,6 +5,12 @@ VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Software-Construction", "Software-Construction.csproj", "{8614C616-7F9A-46F5-9EB1-A8118932F820}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "C#api", "C#api", "{EFE512D5-2DFF-464C-A6FE-5FB1B377CA3D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{9EC93130-1353-4476-8E4C-73FB52B2533A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Unittests", "C#api\Tests\Unittests\Unittests.csproj", "{373723E7-7D12-47BF-8850-92B99E595C86}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,11 +21,19 @@ Global
 		{8614C616-7F9A-46F5-9EB1-A8118932F820}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8614C616-7F9A-46F5-9EB1-A8118932F820}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8614C616-7F9A-46F5-9EB1-A8118932F820}.Release|Any CPU.Build.0 = Release|Any CPU
+		{373723E7-7D12-47BF-8850-92B99E595C86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{373723E7-7D12-47BF-8850-92B99E595C86}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{373723E7-7D12-47BF-8850-92B99E595C86}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{373723E7-7D12-47BF-8850-92B99E595C86}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E8CD21F8-27CA-4E7D-96E3-DEFECA4AB91D}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{9EC93130-1353-4476-8E4C-73FB52B2533A} = {EFE512D5-2DFF-464C-A6FE-5FB1B377CA3D}
+		{373723E7-7D12-47BF-8850-92B99E595C86} = {9EC93130-1353-4476-8E4C-73FB52B2533A}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Unittests voor Modelmapping.

Voor elke model, wordt er wat json data geprobeerd erin te verwerken, en er wordt nagegaan of deze geconvert wordt in een object voor dat model. Dit wordt gedaan om dus de limitaties van de models te vinden en het duidelijk is vanaf welk punt het data niet meer geconvert kan worden naar een object bij bepaalde models.

Er zijn Tests die in zowel happy als non happy path style zijn geschreven.

Ten slotte ook het runnen en krijgen van coverage van de unittests ook in de pipeline verwerkt.