### PR TITLE
Pagination

### DIFF
--- a/C#api/Controllers/ClientsController.cs
+++ b/C#api/Controllers/ClientsController.cs
@@ -36,7 +36,9 @@ public class ClientsController : BaseApiController
         [FromQuery] string country = null,
         [FromQuery] string contactName = null,
         [FromQuery] string contactPhone = null,
-        [FromQuery] string contactEmail = null)
+        [FromQuery] string contactEmail = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "clients", "get");
         if (auth != null) return auth;
@@ -49,7 +51,19 @@ public class ClientsController : BaseApiController
             {
                 return BadRequest("Error, er is geen Client(s) gevonden met deze gegevens.");
             }
-            return Ok(clients);
+
+            var paginatedClients = clients.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+            var totalClients = clients.Count;
+
+            var response = new
+            {
+                TotalCount = totalClients,
+                Page = page,
+                PageSize = pageSize,
+                Clients = paginatedClients
+            };
+
+            return Ok(response);
         }
         catch (ArgumentException ex)
         {
@@ -202,4 +216,3 @@ public class ClientsController : BaseApiController
         return Ok();
     }
 }
-

--- a/C#api/Controllers/ClientsController.cs
+++ b/C#api/Controllers/ClientsController.cs
@@ -16,13 +16,17 @@ public class ClientsController : BaseApiController
     }
 
     [HttpGet]
-    public IActionResult GetClients()
+    public IActionResult GetClients(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10
+    )
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "clients", "get");
         if (auth != null) return auth;
 
         var clients = DataProvider.fetch_client_pool().GetClients();
-        return Ok(clients);
+        var response = PaginationHelper.Paginate(clients, page, pageSize);
+        return Ok(response);
     }
 
     [HttpGet("search")]

--- a/C#api/Controllers/ClientsController.cs
+++ b/C#api/Controllers/ClientsController.cs
@@ -51,18 +51,7 @@ public class ClientsController : BaseApiController
             {
                 return BadRequest("Error, er is geen Client(s) gevonden met deze gegevens.");
             }
-
-            var paginatedClients = clients.Skip((page - 1) * pageSize).Take(pageSize).ToList();
-            var totalClients = clients.Count;
-
-            var response = new
-            {
-                TotalCount = totalClients,
-                Page = page,
-                PageSize = pageSize,
-                Clients = paginatedClients
-            };
-
+            var response = PaginationHelper.Paginate(clients, page, pageSize);
             return Ok(response);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/InventoriesController.cs
+++ b/C#api/Controllers/InventoriesController.cs
@@ -24,7 +24,7 @@ public class InventoriesController : BaseApiController
 
         var inventories = DataProvider.fetch_inventory_pool().GetInventories();
 
-        if (auth is OkResult)
+    if (auth is OkResult)
         {
             var user = AuthProvider.GetUser(Request.Headers["API_KEY"]);
             var locations = DataProvider.fetch_location_pool().GetLocations();
@@ -32,16 +32,7 @@ public class InventoriesController : BaseApiController
             inventories = inventories.Where(x => x.Locations.Any(y => locationids.Contains(y))).ToList();
         }
 
-        var paginatedInventories = inventories.Skip((page - 1) * pageSize).Take(pageSize).ToList();
-        var totalInventories = inventories.Count;
-
-        var response = new
-        {
-            TotalCount = totalInventories,
-            Page = page,
-            PageSize = pageSize,
-            Inventories = paginatedInventories
-        };
+        var response = PaginationHelper.Paginate(inventories, page, pageSize);
 
         return Ok(response);
     }

--- a/C#api/Controllers/InventoriesController.cs
+++ b/C#api/Controllers/InventoriesController.cs
@@ -15,7 +15,9 @@ public class InventoriesController : BaseApiController
     }
 
     [HttpGet]
-    public IActionResult GetInventories()
+    public IActionResult GetInventories(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "inventories", "get");
         if (auth is UnauthorizedResult) return auth;
@@ -30,7 +32,18 @@ public class InventoriesController : BaseApiController
             inventories = inventories.Where(x => x.Locations.Any(y => locationids.Contains(y))).ToList();
         }
 
-        return Ok(inventories);
+        var paginatedInventories = inventories.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+        var totalInventories = inventories.Count;
+
+        var response = new
+        {
+            TotalCount = totalInventories,
+            Page = page,
+            PageSize = pageSize,
+            Inventories = paginatedInventories
+        };
+
+        return Ok(response);
     }
 
     [HttpGet("{id}")]

--- a/C#api/Controllers/Item_GroupsController.cs
+++ b/C#api/Controllers/Item_GroupsController.cs
@@ -14,13 +14,27 @@ public class Item_GroupsController : BaseApiController
     }
 
     [HttpGet]
-    public IActionResult GetItemGroups()
+    public IActionResult GetItemGroups(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "item_groups", "get");
         if (auth != null) return auth;
 
         var itemGroups = DataProvider.fetch_itemgroup_pool().GetItemGroups();
-        return Ok(itemGroups);
+
+        var paginatedItemGroups = itemGroups.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+        var totalItemGroups = itemGroups.Count;
+
+        var response = new
+        {
+            TotalCount = totalItemGroups,
+            Page = page,
+            PageSize = pageSize,
+            ItemGroups = paginatedItemGroups
+        };
+
+        return Ok(response);
     }
 
     [HttpGet("{id}")]

--- a/C#api/Controllers/Item_GroupsController.cs
+++ b/C#api/Controllers/Item_GroupsController.cs
@@ -23,16 +23,7 @@ public class Item_GroupsController : BaseApiController
 
         var itemGroups = DataProvider.fetch_itemgroup_pool().GetItemGroups();
 
-        var paginatedItemGroups = itemGroups.Skip((page - 1) * pageSize).Take(pageSize).ToList();
-        var totalItemGroups = itemGroups.Count;
-
-        var response = new
-        {
-            TotalCount = totalItemGroups,
-            Page = page,
-            PageSize = pageSize,
-            ItemGroups = paginatedItemGroups
-        };
+        var response = PaginationHelper.Paginate(itemGroups, page, pageSize);
 
         return Ok(response);
     }

--- a/C#api/Controllers/Item_LinesController.cs
+++ b/C#api/Controllers/Item_LinesController.cs
@@ -14,13 +14,18 @@ public class Item_LinesController : BaseApiController
     }
 
     [HttpGet]
-    public IActionResult GetItemLines()
+    public IActionResult GetItemLines(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "item_lines", "get");
         if (auth != null) return auth;
 
         var itemLines = DataProvider.fetch_itemline_pool().GetItemLines();
-        return Ok(itemLines);
+
+        var response = PaginationHelper.Paginate(itemLines, page, pageSize);
+
+        return Ok(response);
     }
 
     [HttpGet("{id}")]

--- a/C#api/Controllers/Item_TypesController.cs
+++ b/C#api/Controllers/Item_TypesController.cs
@@ -14,13 +14,18 @@ public class Item_TypesController : BaseApiController
     }
 
     [HttpGet]
-    public IActionResult GetItemTypes()
+    public IActionResult GetItemTypes(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "item_types", "get");
         if (auth != null) return auth;
 
         var itemTypes = DataProvider.fetch_itemtype_pool().GetItemTypes();
-        return Ok(itemTypes);
+
+        var response = PaginationHelper.Paginate(itemTypes, page, pageSize);
+
+        return Ok(response);
     }
 
     [HttpGet("{id}")]

--- a/C#api/Controllers/ItemsController.cs
+++ b/C#api/Controllers/ItemsController.cs
@@ -14,7 +14,9 @@ public class ItemsController : BaseApiController
     }
 
     [HttpGet]
-    public IActionResult GetItems()
+    public IActionResult GetItems(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "items", "get");
         if (auth is UnauthorizedResult) return auth;
@@ -31,7 +33,8 @@ public class ItemsController : BaseApiController
             var ids = inventories.Where(x => x.Locations.Any(y => locationids.Contains(y))).Select(x => x.Item_Id);
             foreach (var id in ids) newitems.Add(DataProvider.fetch_item_pool().GetItem(id));
         }
-        return Ok(newitems.Count == 0 ? items : newitems);
+        var paginatedItems = PaginationHelper.Paginate(newitems.Count == 0 ? items : newitems, page, pageSize);
+        return Ok(paginatedItems);
     }
 
     [HttpGet("{id}")]

--- a/C#api/Controllers/ItemsController.cs
+++ b/C#api/Controllers/ItemsController.cs
@@ -88,7 +88,9 @@ public class ItemsController : BaseApiController
         [FromQuery] string modelNumber = null, 
         [FromQuery] string commodityCode = null, 
         [FromQuery] string supplierCode = null, 
-        [FromQuery] string supplierPartNumber = null)
+        [FromQuery] string supplierPartNumber = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "items", "get");
         if (auth != null) return auth;
@@ -110,6 +112,7 @@ public class ItemsController : BaseApiController
                 return NoContent();
             }
             
+            var response = PaginationHelper.Paginate(items, page, pageSize);
             return Ok(items);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/LocationsController.cs
+++ b/C#api/Controllers/LocationsController.cs
@@ -14,7 +14,9 @@ public class LocationsController : BaseApiController
     }
 
     [HttpGet]
-    public IActionResult GetLocations()
+    public IActionResult GetLocations(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "locations", "get");
         if (auth is UnauthorizedResult) return auth;
@@ -27,7 +29,8 @@ public class LocationsController : BaseApiController
             locations = locations.Where(x => user.OwnWarehouses.Contains(x.Warehouse_Id)).ToList();
         }
 
-        return Ok(locations);
+        var response = PaginationHelper.Paginate(locations, page, pageSize);
+        return Ok(response);
     }
 
     [HttpGet("{id}")]

--- a/C#api/Controllers/LocationsController.cs
+++ b/C#api/Controllers/LocationsController.cs
@@ -59,7 +59,9 @@ public class LocationsController : BaseApiController
         [FromQuery] string created_At = null, 
         [FromQuery] string updated_At = null, 
         [FromQuery] int? warehouseId = null, 
-        [FromQuery] string code = null)
+        [FromQuery] string code = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "locations", "get");
         if (auth != null) return auth;
@@ -79,6 +81,7 @@ public class LocationsController : BaseApiController
                 return NoContent();
             }
 
+            var response = PaginationHelper.Paginate(locations, page, pageSize);
             return Ok(locations);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/OrdersController.cs
+++ b/C#api/Controllers/OrdersController.cs
@@ -14,7 +14,9 @@ public class OrdersController : BaseApiController
     }
 
     [HttpGet]
-    public IActionResult GetOrders()
+    public IActionResult GetOrders(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "orders", "get");
         if (auth is UnauthorizedResult) return auth;
@@ -26,7 +28,9 @@ public class OrdersController : BaseApiController
             var user = AuthProvider.GetUser(Request.Headers["API_KEY"]);
             orders = orders.Where(o => user.OwnWarehouses.Contains(o.Warehouse_Id)).ToList();
         }
-        return Ok(orders);
+
+        var response = PaginationHelper.Paginate(orders, page, pageSize);
+        return Ok(response);
     }
 
     [HttpGet("{id}")]

--- a/C#api/Controllers/OrdersController.cs
+++ b/C#api/Controllers/OrdersController.cs
@@ -80,7 +80,9 @@ public class OrdersController : BaseApiController
         [FromQuery] int? billTo = null,
         [FromQuery] int? shipmentId = null,
         [FromQuery] string created_At = null,
-        [FromQuery] string updated_At = null)
+        [FromQuery] string updated_At = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "orders", "get");
         if (auth != null) return auth;
@@ -110,6 +112,7 @@ public class OrdersController : BaseApiController
                 return NoContent();
             }
 
+            var response = PaginationHelper.Paginate(orders, page, pageSize);
             return Ok(orders);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/ShipmentsController.cs
+++ b/C#api/Controllers/ShipmentsController.cs
@@ -77,7 +77,9 @@ public class ShipmentsController : BaseApiController
         [FromQuery] string shipmentDate = null,
         [FromQuery] string shipmentType = null,
         [FromQuery] string shipmentStatus = null,
-        [FromQuery] string carrierCode = null)
+        [FromQuery] string carrierCode = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "shipments", "get");
         if (auth != null) return auth;
@@ -99,7 +101,7 @@ public class ShipmentsController : BaseApiController
             {
                 return NoContent();
             }
-
+            var response = PaginationHelper.Paginate(shipments, page, pageSize);
             return Ok(shipments);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/ShipmentsController.cs
+++ b/C#api/Controllers/ShipmentsController.cs
@@ -14,13 +14,16 @@ public class ShipmentsController : BaseApiController
     }
 
     [HttpGet]
-    public IActionResult GetShipments()
+    public IActionResult GetShipments(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "shipments", "get");
         if (auth != null) return auth;
 
         var shipments = DataProvider.fetch_shipment_pool().GetShipments();
-        return Ok(shipments);
+        var response = PaginationHelper.Paginate(shipments, pageSize, page);
+        return Ok(response);
     }
 
     [HttpGet("{id}")]

--- a/C#api/Controllers/SuppliersController.cs
+++ b/C#api/Controllers/SuppliersController.cs
@@ -14,13 +14,16 @@ public class SuppliersController : BaseApiController
     }
 
     [HttpGet]
-    public IActionResult GetSuppliers()
+    public IActionResult GetSuppliers(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "suppliers", "get");
         if (auth != null) return auth;
 
         var suppliers = DataProvider.fetch_supplier_pool().GetSuppliers();
-        return Ok(suppliers);
+        var response = PaginationHelper.Paginate(suppliers, page, pageSize);
+        return Ok(response);
     }
 
     [HttpGet("{id}")]

--- a/C#api/Controllers/SuppliersController.cs
+++ b/C#api/Controllers/SuppliersController.cs
@@ -52,7 +52,9 @@ public class SuppliersController : BaseApiController
         [FromQuery] string city = null, 
         [FromQuery] string country = null,
         [FromQuery] string code = null, 
-        [FromQuery] string reference = null)
+        [FromQuery] string reference = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "suppliers", "get");
         if (auth != null) return auth;
@@ -72,6 +74,7 @@ public class SuppliersController : BaseApiController
                 return NoContent();
             }
 
+            var response = PaginationHelper.Paginate(suppliers, page, pageSize);
             return Ok(suppliers);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/TransfersController.cs
+++ b/C#api/Controllers/TransfersController.cs
@@ -64,7 +64,10 @@ public class TransfersController : BaseApiController
         [FromQuery] int? transferFrom = null,
         [FromQuery] int? transferTo = null,
         [FromQuery] string transferStatus = null,
-        [FromQuery] string createdAt = null)
+        [FromQuery] string createdAt = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
+        
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "transfers", "get");
         if (auth != null) return auth;
@@ -84,6 +87,7 @@ public class TransfersController : BaseApiController
                 return NoContent();
             }
 
+            var response = PaginationHelper.Paginate(transfers, page, pageSize);
             return Ok(transfers);
         }
         catch (ArgumentException ex)

--- a/C#api/Controllers/TransfersController.cs
+++ b/C#api/Controllers/TransfersController.cs
@@ -14,13 +14,16 @@ public class TransfersController : BaseApiController
     }
 
     [HttpGet]
-    public IActionResult GetTransfers()
+    public IActionResult GetTransfers(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "transfers", "get");
         if (auth != null) return auth;
 
         var transfers = DataProvider.fetch_transfer_pool().GetTransfers();
-        return Ok(transfers);
+        var response = PaginationHelper.Paginate(transfers, page, pageSize);
+        return Ok(response);
     }
 
     [HttpGet("{id}")]

--- a/C#api/Controllers/WarehousesController.cs
+++ b/C#api/Controllers/WarehousesController.cs
@@ -14,13 +14,16 @@ public class WarehousesController : BaseApiController
     }
 
     [HttpGet]
-    public IActionResult GetWarehouses()
+    public IActionResult GetWarehouses(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "warehouses", "get");
         if (auth != null) return auth;
 
         var warehouses = DataProvider.fetch_warehouse_pool().GetWarehouses();
-        return Ok(warehouses);
+        var response = PaginationHelper.Paginate(warehouses, page, pageSize);
+        return Ok(response);
     }
 
     [HttpGet("{id}")]

--- a/C#api/Controllers/WarehousesController.cs
+++ b/C#api/Controllers/WarehousesController.cs
@@ -56,7 +56,9 @@ public class WarehousesController : BaseApiController
         [FromQuery] string province = null,
         [FromQuery] string country = null,
         [FromQuery] string createdAt = null,
-        [FromQuery] string updatedAt = null)
+        [FromQuery] string updatedAt = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
         var auth = CheckAuthorization(Request.Headers["API_KEY"], "warehouses", "get");
         if (auth != null) return auth;
@@ -79,7 +81,8 @@ public class WarehousesController : BaseApiController
             {
                 return NoContent();
             }
-
+            
+            var response = PaginationHelper.Paginate(warehouses, page, pageSize);
             return Ok(warehouses);
         }
         catch (ArgumentException ex)

--- a/C#api/Helpers/PaginationHelper.cs
+++ b/C#api/Helpers/PaginationHelper.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public static class PaginationHelper
+{
+    public static PaginatedResponse<T> Paginate<T>(IEnumerable<T> source, int page, int pageSize)
+    {
+        var totalItems = source.Count();
+        var paginatedItems = source.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+
+        return new PaginatedResponse<T>
+        {
+            TotalCount = totalItems,
+            Page = page,
+            PageSize = pageSize,
+            Items = paginatedItems
+        };
+    }
+}
+
+public class PaginatedResponse<T>
+{
+    public int TotalCount { get; set; }
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+    public List<T> Items { get; set; }
+}

--- a/C#api/Tests/Security; Rolls/test_floor_manager.py
+++ b/C#api/Tests/Security; Rolls/test_floor_manager.py
@@ -76,7 +76,7 @@ class FloorManagerApiTests(unittest.TestCase):
         self.assertNotEqual(response.json(), self.GetJsonData("locations"))
         check = all(
             i["Warehouse_Id"] == 7 or i["Warehouse_Id"] == 8 or i["Warehouse_Id"] == 9
-            for i in response.json()
+            for i in response.json()["Items"]
         )
         self.assertTrue(check)
 

--- a/C#api/Tests/Security; Rolls/test_inventory_manager.py
+++ b/C#api/Tests/Security; Rolls/test_inventory_manager.py
@@ -100,7 +100,7 @@ class InventoryManagerApiTests(unittest.TestCase):
         self.assertNotEqual(response.json(), self.GetJsonData("locations"))
         check = all(
             i["Warehouse_Id"] == 10 or i["Warehouse_Id"] == 11 or i["Warehouse_Id"] == 12
-            for i in response.json()
+            for i in response.json()["Items"]
         )
         self.assertTrue(check)
 

--- a/C#api/Tests/Security; Rolls/test_operative.py
+++ b/C#api/Tests/Security; Rolls/test_operative.py
@@ -74,11 +74,11 @@ class OperativeApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotEqual(response.json(), self.GetJsonData("items"))
         inventory_dict = {item["Item_Id"]: item for item in self.GetJsonData("inventories")}
-        inventorylist = [i for i in response.json() if i["Uid"] in inventory_dict and inventory_dict[i["Uid"]] == i["Uid"]]
+        inventorylist = [i for i in response.json()["Items"] if i["Uid"] in inventory_dict and inventory_dict[i["Uid"]] == i["Uid"]]
         for i in inventorylist:
             check = any(
                 y["Warehouse_Id"] == 4 or y["Warehouse_Id"] == 5 or y["Warehouse_Id"] == 6
-                for y in i["Locations"]["Items"]
+                for y in i["Locations"]
             )
             self.assertTrue(check)
 

--- a/C#api/Tests/Security; Rolls/test_operative.py
+++ b/C#api/Tests/Security; Rolls/test_operative.py
@@ -78,7 +78,7 @@ class OperativeApiTests(unittest.TestCase):
         for i in inventorylist:
             check = any(
                 y["Warehouse_Id"] == 4 or y["Warehouse_Id"] == 5 or y["Warehouse_Id"] == 6
-                for y in i["Locations"]
+                for y in i["Locations"]["Items"]
             )
             self.assertTrue(check)
 

--- a/C#api/Tests/Security; Rolls/test_supervisor.py
+++ b/C#api/Tests/Security; Rolls/test_supervisor.py
@@ -104,7 +104,7 @@ class SupervisorApiTests(unittest.TestCase):
         self.assertNotEqual(response.json(), self.GetJsonData("orders"))
         check = all(
             order["Warehouse_Id"] == 1 or order["Warehouse_Id"] == 2 or order["Warehouse_Id"] == 3
-            for order in response.json()
+            for order in response.json()["Items"]
         )
         self.assertTrue(check)
 
@@ -114,7 +114,7 @@ class SupervisorApiTests(unittest.TestCase):
         self.assertNotEqual(response.json(), self.GetJsonData("inventories"))
         location_dict = {x["Id"]: x for x in self.GetJsonData("locations")}
         warehouse_ids = {1, 2, 3}
-        for i in response.json():
+        for i in response.json()["Items"]:
             locationlist = [location_dict[y] for y in i["Locations"] if y in location_dict]
             check = any(y["Warehouse_Id"] in warehouse_ids for y in locationlist)
             self.assertTrue(check)

--- a/C#api/Tests/test_clients.py
+++ b/C#api/Tests/test_clients.py
@@ -66,40 +66,38 @@ class ApiClientsTests(unittest.TestCase):
     def test_search_by_name(self):
         response = self.client.get(f"clients/search?name=Raymond Inc")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, response.json()[0])
-        for name in response.json():
-            self.assertEqual(name['Name'], "Raymond Inc")
+        self.assertTrue(len(response.json()) > 0, response.json())
+        for client in response.json()["Items"]:
+            self.assertEqual(client['Name'], "Raymond Inc")
     
     def test_search_by_city(self):
         response = self.client.get(f"clients/search?city=Pierceview")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, response.json()[0])
-        for city in response.json():
-            if self.assertEqual(city['City'], "Pierceview"):
-                return city
-            else:
-                return False
+        self.assertTrue(len(response.json()) > 0, response.json())
+        for city in response.json()["Items"]:
+            self.assertEqual(city['City'], "Pierceview")
                 
     def test_search_by_country(self):
         response = self.client.get(f"clients/search?country=United States")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        for country in response.json():
+        for country in response.json()["Items"]:
             self.assertEqual(country['Country'], "United States")
     
     def test_search_by_name_and_city(self):
         response = self.client.get(f"clients/search?name=Raymond Inc&city=Pierceview")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(len(response.json()) > 0, response.json())
-        for x in response.json():
-            self.assertEqual(x['Name'], "Raymond Inc")
-            self.assertEqual(x['City'], "Pierceview")
+        json_response = response.json()
+        self.assertTrue(len(json_response) > 0, response.json)
+        for client in json_response["Items"]:
+            self.assertEqual(client['Name'], "Raymond Inc")
+            self.assertEqual(client['City'], "Pierceview")
     
     def test_search_by_name_and_country(self):
         response = self.client.get(f"clients/search?name=Raymond Inc&country=United States")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        for x in response.json():
+        for x in response.json()["Items"]:
             self.assertEqual(x['Name'], "Raymond Inc")
             self.assertEqual(x['Country'], "United States")
     
@@ -107,7 +105,7 @@ class ApiClientsTests(unittest.TestCase):
         response = self.client.get(f"clients/search?city=Pierceview&country=United States")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        for x in response.json():
+        for x in response.json()["Items"]:
             self.assertEqual(x['City'], "Pierceview")
             self.assertEqual(x['Country'], "United States")
     
@@ -115,7 +113,7 @@ class ApiClientsTests(unittest.TestCase):
         response = self.client.get(f"clients/search?name=Raymond Inc&city=Pierceview&country=United States")
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json()) > 0, response.json())
-        for x in response.json():
+        for x in response.json()["Items"]:
             self.assertEqual(x['Name'], "Raymond Inc")
             self.assertEqual(x['City'], "Pierceview")
             self.assertEqual(x['Country'], "United States")

--- a/C#api/Tests/test_pagination.py
+++ b/C#api/Tests/test_pagination.py
@@ -1,0 +1,57 @@
+import unittest
+
+class PaginationHelper:
+    @staticmethod
+    def paginate(source, page, page_size):
+        total_items = len(source)
+        paginated_items = source[(page - 1) * page_size: page * page_size]
+        return {
+            'TotalCount': total_items,
+            'Page': page,
+            'PageSize': page_size,
+            'Items': paginated_items
+        }
+
+class TestPaginationHelper(unittest.TestCase):
+    def test_paginate_normal_list(self):
+        source = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        result = PaginationHelper.paginate(source, 2, 3)
+        self.assertEqual(result['TotalCount'], 10)
+        self.assertEqual(result['Page'], 2)
+        self.assertEqual(result['PageSize'], 3)
+        self.assertEqual(result['Items'], [4, 5, 6])
+
+    def test_paginate_empty_list(self):
+        source = []
+        result = PaginationHelper.paginate(source, 1, 3)
+        self.assertEqual(result['TotalCount'], 0)
+        self.assertEqual(result['Page'], 1)
+        self.assertEqual(result['PageSize'], 3)
+        self.assertEqual(result['Items'], [])
+
+    def test_paginate_single_item(self):
+        source = [1]
+        result = PaginationHelper.paginate(source, 1, 3)
+        self.assertEqual(result['TotalCount'], 1)
+        self.assertEqual(result['Page'], 1)
+        self.assertEqual(result['PageSize'], 3)
+        self.assertEqual(result['Items'], [1])
+
+    def test_paginate_page_size_larger_than_list(self):
+        source = [1, 2, 3]
+        result = PaginationHelper.paginate(source, 1, 5)
+        self.assertEqual(result['TotalCount'], 3)
+        self.assertEqual(result['Page'], 1)
+        self.assertEqual(result['PageSize'], 5)
+        self.assertEqual(result['Items'], [1, 2, 3])
+
+    def test_paginate_page_number_exceeds_total_pages(self):
+        source = [1, 2, 3, 4, 5]
+        result = PaginationHelper.paginate(source, 3, 2)
+        self.assertEqual(result['TotalCount'], 5)
+        self.assertEqual(result['Page'], 3)
+        self.assertEqual(result['PageSize'], 2)
+        self.assertEqual(result['Items'], [])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/C#api/Tests/test_pagination.py
+++ b/C#api/Tests/test_pagination.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime
 
 class PaginationHelper:
     @staticmethod
@@ -51,7 +52,7 @@ class TestPaginationHelper(unittest.TestCase):
         self.assertEqual(result['TotalCount'], 5)
         self.assertEqual(result['Page'], 3)
         self.assertEqual(result['PageSize'], 2)
-        self.assertEqual(result['Items'], [])
-
+        self.assertEqual(result['Items'], [5])
+        
 if __name__ == '__main__':
     unittest.main()

--- a/Software-Construction.csproj
+++ b/Software-Construction.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hier werd volgende verwerkt As a System, it should support pagination when receiving large data sets in the reponse of a request. 
Er wordt gemaakt dat bij de HttpGet van model met get van alle informatie die staan in de model.
Hiernaast werd voor search toegevoegd pagination.
In code van deze pull request werd pagination met 10 items per page.
er word zo in thunder client te zien voor page 2
http://localhost/api/clients?page=2&pageSize=10