### PR TITLE
endpoint to view some details

### DIFF
--- a/C#api/Controllers/ItemsController.cs
+++ b/C#api/Controllers/ItemsController.cs
@@ -143,7 +143,7 @@ public class ItemsController : BaseApiController, ILoggableAction
         var item = DataProvider.fetch_item_pool().GetItem(id);
         if (item == null)
         {
-            return NotFound("Item not found");
+            return BadRequest("Invalid Item ID");
         }
 
         var supplier = DataProvider.fetch_supplier_pool().GetSupplier(item.Supplier_Id);
@@ -161,7 +161,7 @@ public class ItemsController : BaseApiController, ILoggableAction
         var item = DataProvider.fetch_item_pool().GetItem(id);
         if (item == null)
         {
-            return NotFound("Item not found");
+            return BadRequest("Invalid Item ID");
         }
 
         object detail = null;

--- a/C#api/Controllers/ItemsController.cs
+++ b/C#api/Controllers/ItemsController.cs
@@ -143,7 +143,7 @@ public class ItemsController : BaseApiController, ILoggableAction
         var item = DataProvider.fetch_item_pool().GetItem(id);
         if (item == null)
         {
-            return BadRequest("Invalid Item ID");
+            return NoContent();
         }
 
         var supplier = DataProvider.fetch_supplier_pool().GetSupplier(item.Supplier_Id);
@@ -161,7 +161,7 @@ public class ItemsController : BaseApiController, ILoggableAction
         var item = DataProvider.fetch_item_pool().GetItem(id);
         if (item == null)
         {
-            return BadRequest("Invalid Item ID");
+            return NoContent();
         }
 
         object detail = null;
@@ -177,7 +177,7 @@ public class ItemsController : BaseApiController, ILoggableAction
                 detail = DataProvider.fetch_itemtype_pool().GetItemType(item.Item_Type);
                 break;
             default:
-                return BadRequest("Invalid detail type");
+                return NoContent();
         }
 
         if (detail == null) return NoContent();

--- a/C#api/Controllers/ItemsController.cs
+++ b/C#api/Controllers/ItemsController.cs
@@ -133,6 +133,58 @@ public class ItemsController : BaseApiController, ILoggableAction
             return BadRequest(ex.Message);
         }
     }
+
+    [HttpGet("{id}/supplier")]
+    public IActionResult GetItemSupplier(string id)
+    {
+        var auth = CheckAuthorization(Request.Headers["API_KEY"], "items", "get");
+        if (auth is UnauthorizedResult) return auth;
+
+        var item = DataProvider.fetch_item_pool().GetItem(id);
+        if (item == null)
+        {
+            return NotFound("Item not found");
+        }
+
+        var supplier = DataProvider.fetch_supplier_pool().GetSupplier(item.Supplier_Id);
+        if (supplier == null) return NoContent();
+
+        return Ok(supplier);
+    }
+
+    [HttpGet("{id}/{detailType}")]
+    public IActionResult GetItemDetails(string id, string detailType)
+    {
+        var auth = CheckAuthorization(Request.Headers["API_KEY"], "items", "get");
+        if (auth is UnauthorizedResult) return auth;
+
+        var item = DataProvider.fetch_item_pool().GetItem(id);
+        if (item == null)
+        {
+            return NotFound("Item not found");
+        }
+
+        object detail = null;
+        switch (detailType.ToLower())
+        {
+            case "itemline":
+                detail = DataProvider.fetch_itemline_pool().GetItemLine(item.Item_Line);
+                break;
+            case "itemgroup":
+                detail = DataProvider.fetch_itemgroup_pool().GetItemGroup(item.Item_Group);
+                break;
+            case "itemtype":
+                detail = DataProvider.fetch_itemtype_pool().GetItemType(item.Item_Type);
+                break;
+            default:
+                return BadRequest("Invalid detail type");
+        }
+
+        if (detail == null) return NoContent();
+
+        return Ok(detail);
+    }
+
     [LogRequest]
     [HttpPost]
     public IActionResult CreateItem([FromBody] Item item)

--- a/C#api/Controllers/LocationsController.cs
+++ b/C#api/Controllers/LocationsController.cs
@@ -96,7 +96,7 @@ public class LocationsController : BaseApiController
         var location = DataProvider.fetch_location_pool().GetLocation(id);
         if (location == null)
         {
-            return BadRequest("Invalid location ID");
+            return NoContent();
         }
 
         var warehouse = DataProvider.fetch_warehouse_pool().GetWarehouse(location.Warehouse_Id);

--- a/C#api/Controllers/LocationsController.cs
+++ b/C#api/Controllers/LocationsController.cs
@@ -87,6 +87,24 @@ public class LocationsController : BaseApiController
         }
     }
 
+    [HttpGet("{id}/warehouse")]
+    public IActionResult GetLocationWarehouse(int id)
+    {
+        var auth = CheckAuthorization(Request.Headers["API_KEY"], "locations", "get");
+        if (auth is UnauthorizedResult) return auth;
+
+        var location = DataProvider.fetch_location_pool().GetLocation(id);
+        if (location == null)
+        {
+            return NotFound("Location not found");
+        }
+
+        var warehouse = DataProvider.fetch_warehouse_pool().GetWarehouse(location.Warehouse_Id);
+        if (warehouse == null) return NoContent();
+
+        return Ok(warehouse);
+    }
+
     [HttpPost]
     public IActionResult CreateLocation([FromBody] Location location)
     {

--- a/C#api/Controllers/LocationsController.cs
+++ b/C#api/Controllers/LocationsController.cs
@@ -96,7 +96,7 @@ public class LocationsController : BaseApiController
         var location = DataProvider.fetch_location_pool().GetLocation(id);
         if (location == null)
         {
-            return NotFound("Location not found");
+            return BadRequest("Invalid location ID");
         }
 
         var warehouse = DataProvider.fetch_warehouse_pool().GetWarehouse(location.Warehouse_Id);

--- a/C#api/Controllers/OrdersController.cs
+++ b/C#api/Controllers/OrdersController.cs
@@ -116,7 +116,7 @@ public class OrdersController : BaseApiController, ILoggableAction
         var order = DataProvider.fetch_order_pool().GetOrder(id);
         if (order == null)
         {
-            return BadRequest("Invalid order ID");
+            return NoContent();
         }
 
         var warehouse = DataProvider.fetch_warehouse_pool().GetWarehouse(order.Warehouse_Id);

--- a/C#api/Controllers/OrdersController.cs
+++ b/C#api/Controllers/OrdersController.cs
@@ -106,6 +106,25 @@ public class OrdersController : BaseApiController, ILoggableAction
             return BadRequest(ex.Message);
         }
     }
+
+    [HttpGet("{id}/warehouse")]
+    public IActionResult GetOrderWarehouse(int id)
+    {
+        var auth = CheckAuthorization(Request.Headers["API_KEY"], "orders", "get");
+        if (auth is UnauthorizedResult) return auth;
+
+        var order = DataProvider.fetch_order_pool().GetOrder(id);
+        if (order == null)
+        {
+            return NotFound("Order not found");
+        }
+
+        var warehouse = DataProvider.fetch_warehouse_pool().GetWarehouse(order.Warehouse_Id);
+        if (warehouse == null) return NoContent();
+
+        return Ok(warehouse);
+}
+
     [LogRequest]
     [HttpPost]
     public IActionResult CreateOrder([FromBody] Order order)

--- a/C#api/Controllers/OrdersController.cs
+++ b/C#api/Controllers/OrdersController.cs
@@ -116,7 +116,7 @@ public class OrdersController : BaseApiController, ILoggableAction
         var order = DataProvider.fetch_order_pool().GetOrder(id);
         if (order == null)
         {
-            return NotFound("Order not found");
+            return BadRequest("Invalid order ID");
         }
 
         var warehouse = DataProvider.fetch_warehouse_pool().GetWarehouse(order.Warehouse_Id);

--- a/C#api/Controllers/ShipmentsController.cs
+++ b/C#api/Controllers/ShipmentsController.cs
@@ -107,6 +107,22 @@ public class ShipmentsController : BaseApiController, ILoggableAction
             return BadRequest(ex.Message);
         }
     }
+
+    [HttpGet("{id}/order")]
+    public IActionResult GetShipmentOrder(int id)
+    {
+        var auth = CheckAuthorization(Request.Headers["API_KEY"], "shipments", "getsingle");
+        if (auth != null) return auth;
+
+        var shipment = DataProvider.fetch_shipment_pool().GetShipment(id);
+        if (shipment == null) return NoContent();
+
+        var order = DataProvider.fetch_order_pool().GetOrder(shipment.Order_Id);
+        if (order == null) return NoContent();
+
+        return Ok(order);
+    }
+
     [LogRequest]
     [HttpPost]
     public IActionResult CreateShipment([FromBody] Shipment shipment)

--- a/C#api/Controllers/ShipmentsController.cs
+++ b/C#api/Controllers/ShipmentsController.cs
@@ -115,7 +115,7 @@ public class ShipmentsController : BaseApiController, ILoggableAction
         if (auth != null) return auth;
 
         var shipment = DataProvider.fetch_shipment_pool().GetShipment(id);
-        if (shipment == null) return NoContent();
+        if (shipment == null) return BadRequest("Invalid Shipment ID");
 
         var order = DataProvider.fetch_order_pool().GetOrder(shipment.Order_Id);
         if (order == null) return NoContent();

--- a/C#api/Controllers/ShipmentsController.cs
+++ b/C#api/Controllers/ShipmentsController.cs
@@ -115,7 +115,7 @@ public class ShipmentsController : BaseApiController, ILoggableAction
         if (auth != null) return auth;
 
         var shipment = DataProvider.fetch_shipment_pool().GetShipment(id);
-        if (shipment == null) return BadRequest("Invalid Shipment ID");
+        if (shipment == null) return NoContent();
 
         var order = DataProvider.fetch_order_pool().GetOrder(shipment.Order_Id);
         if (order == null) return NoContent();

--- a/C#api/Controllers/TransfersController.cs
+++ b/C#api/Controllers/TransfersController.cs
@@ -106,12 +106,12 @@ public class TransfersController : BaseApiController, ILoggableAction
         public IActionResult GetTransferLocations(int id)
         {
             var transfer = DataProvider.fetch_transfer_pool().GetTransfer(id);
-            if (transfer == null) return BadRequest("Invalid Transfer ID");
+            if (transfer == null) return NoContent();
             
             var locationFrom = DataProvider.fetch_location_pool().GetLocation(transfer.Transfer_From ?? 0);
             var locationTo = DataProvider.fetch_location_pool().GetLocation(transfer.Transfer_To ?? 0);
 
-            if (locationFrom == null || locationTo == null) return NoContent();
+            if (locationFrom == null && locationTo == null) return NoContent();
 
             return Ok(new { LocationFrom = locationFrom, LocationTo = locationTo });
 

--- a/C#api/Controllers/TransfersController.cs
+++ b/C#api/Controllers/TransfersController.cs
@@ -101,6 +101,25 @@ public class TransfersController : BaseApiController, ILoggableAction
             return BadRequest(ex.Message);
         }
     }
+
+    [HttpGet("{id}/locations")]
+        public IActionResult GetTransferLocations(int id)
+        {
+            var transfer = DataProvider.fetch_transfer_pool().GetTransfer(id);
+            if (transfer == null)
+            {
+                return NotFound("Transfer not found");
+            }
+
+            var locations = new
+            {
+                SenderLocation = transfer.Transfer_From,
+                ReceiverLocation = transfer.Transfer_To
+            };
+
+            return Ok(locations);
+        }
+
     [LogRequest]
     [HttpPost]
     public IActionResult CreateTransfer([FromBody] Transfer transfer)

--- a/C#api/Controllers/TransfersController.cs
+++ b/C#api/Controllers/TransfersController.cs
@@ -106,18 +106,15 @@ public class TransfersController : BaseApiController, ILoggableAction
         public IActionResult GetTransferLocations(int id)
         {
             var transfer = DataProvider.fetch_transfer_pool().GetTransfer(id);
-            if (transfer == null)
-            {
-                return NotFound("Transfer not found");
-            }
+            if (transfer == null) return BadRequest("Invalid Transfer ID");
+            
+            var locationFrom = DataProvider.fetch_location_pool().GetLocation(transfer.Transfer_From ?? 0);
+            var locationTo = DataProvider.fetch_location_pool().GetLocation(transfer.Transfer_To ?? 0);
 
-            var locations = new
-            {
-                SenderLocation = transfer.Transfer_From,
-                ReceiverLocation = transfer.Transfer_To
-            };
+            if (locationFrom == null || locationTo == null) return NoContent();
 
-            return Ok(locations);
+            return Ok(new { LocationFrom = locationFrom, LocationTo = locationTo });
+
         }
 
     [LogRequest]

--- a/C#api/Tests/test_items.py
+++ b/C#api/Tests/test_items.py
@@ -130,7 +130,44 @@ class ApiItemsTests(unittest.TestCase):
         for item in response.json():
             self.assertEqual(item['Code'], "gVK34692I")
             self.assertEqual(item['Commodity_Code'], "p-69292-Xkv")
-            
+    
+    def test_get_location_warehouse(self):
+        id = "P000006"
+        response = self.client.get(f"items/{id}/supplier")
+        self.assertEqual(response.status_code, 200)
+        supplier = response.json()
+        self.assertEqual(supplier['Id'], 69)
+        self.assertEqual(supplier['Code'], "SUP0069")
+        self.assertEqual(supplier['Name'], "Hunt, Chang and Parker")
+        self.assertEqual(supplier['Address'], "37747 Cassandra Isle")
+
+    def test_get_item_details_itemline(self):
+        id = "P000014"
+        detail_type = "itemline"
+        response = self.client.get(f"items/{id}/{detail_type}")
+        self.assertEqual(response.status_code, 200)
+        detail = response.json()
+        self.assertIsNotNone(detail)
+        self.assertEqual(detail['Id'], 67)
+
+    def test_get_item_details_itemgroup(self):
+        id = "P000014"
+        detail_type = "itemgroup"
+        response = self.client.get(f"items/{id}/{detail_type}")
+        self.assertEqual(response.status_code, 200)
+        detail = response.json()
+        self.assertIsNotNone(detail)
+        self.assertEqual(detail['Id'], 31)
+
+    def test_get_item_details_itemtype(self):
+        id = "P000014"
+        detail_type = "itemtype"
+        response = self.client.get(f"items/{id}/{detail_type}")
+        self.assertEqual(response.status_code, 200)
+        detail = response.json()
+        self.assertIsNotNone(detail)
+        self.assertEqual(detail['Id'], 36)
+      
     # POST tests
     def test_4create_item(self):
         response = self.client.post("items", json=self.new_item)

--- a/C#api/Tests/test_items.py
+++ b/C#api/Tests/test_items.py
@@ -170,23 +170,19 @@ class ApiItemsTests(unittest.TestCase):
     
     def test_get_item_supplier_invalid_id(self):
         response = self.client.get("items/ITEM999/supplier")
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("Invalid Item ID", response.text)
+        self.assertEqual(response.status_code, 204)
     
     def test_get_item_itemline_invalid_id(self):
         response = self.client.get("items/ITEM999/itemline")
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("Invalid Item ID", response.text)
+        self.assertEqual(response.status_code, 204)
     
     def test_get_item_itemgroup_invalid_id(self):
         response = self.client.get("items/ITEM999/itemgroup")
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("Invalid Item ID", response.text)
+        self.assertEqual(response.status_code, 204)
     
     def test_get_item_itemtype_invalid_id(self):
         response = self.client.get("items/ITEM999/itemtype")
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("Invalid Item ID", response.text)
+        self.assertEqual(response.status_code, 204)
         
     # POST tests
     def test_4create_item(self):

--- a/C#api/Tests/test_items.py
+++ b/C#api/Tests/test_items.py
@@ -131,7 +131,7 @@ class ApiItemsTests(unittest.TestCase):
             self.assertEqual(item['Code'], "gVK34692I")
             self.assertEqual(item['Commodity_Code'], "p-69292-Xkv")
     
-    def test_get_location_warehouse(self):
+    def test_get_item_supplier(self):
         id = "P000006"
         response = self.client.get(f"items/{id}/supplier")
         self.assertEqual(response.status_code, 200)
@@ -167,7 +167,27 @@ class ApiItemsTests(unittest.TestCase):
         detail = response.json()
         self.assertIsNotNone(detail)
         self.assertEqual(detail['Id'], 36)
-      
+    
+    def test_get_item_supplier_invalid_id(self):
+        response = self.client.get("items/ITEM999/supplier")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid Item ID", response.text)
+    
+    def test_get_item_itemline_invalid_id(self):
+        response = self.client.get("items/ITEM999/itemline")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid Item ID", response.text)
+    
+    def test_get_item_itemgroup_invalid_id(self):
+        response = self.client.get("items/ITEM999/itemgroup")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid Item ID", response.text)
+    
+    def test_get_item_itemtype_invalid_id(self):
+        response = self.client.get("items/ITEM999/itemtype")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid Item ID", response.text)
+        
     # POST tests
     def test_4create_item(self):
         response = self.client.post("items", json=self.new_item)

--- a/C#api/Tests/test_locations.py
+++ b/C#api/Tests/test_locations.py
@@ -128,8 +128,7 @@ class ApiLocationsTests(unittest.TestCase):
     
     def test_get_location_warehouse_invalid_id(self):
         response = self.client.get("locations/-1/warehouse")
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("Invalid location ID", response.text)
+        self.assertEqual(response.status_code, 204)
        
     # POST tests
     def test_4create_location(self):

--- a/C#api/Tests/test_locations.py
+++ b/C#api/Tests/test_locations.py
@@ -125,6 +125,11 @@ class ApiLocationsTests(unittest.TestCase):
         self.assertIn("Id", warehouse)
         self.assertIn("Name", warehouse)
         self.assertIn("Address", warehouse)
+    
+    def test_get_location_warehouse_invalid_id(self):
+        response = self.client.get("locations/-1/warehouse")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid location ID", response.text)
        
     # POST tests
     def test_4create_location(self):

--- a/C#api/Tests/test_locations.py
+++ b/C#api/Tests/test_locations.py
@@ -117,6 +117,14 @@ class ApiLocationsTests(unittest.TestCase):
             self.assertEqual(x['Code'], "A.1.0")
             self.assertEqual(x['Warehouse_Id'], 1)
 
+    def test_get_location_warehouse(self):
+        id = 1
+        response = self.client.get(f"locations/{id}/warehouse")
+        self.assertEqual(response.status_code, 200)
+        warehouse = response.json()
+        self.assertIn("Id", warehouse)
+        self.assertIn("Name", warehouse)
+        self.assertIn("Address", warehouse)
        
     # POST tests
     def test_4create_location(self):

--- a/C#api/Tests/test_orders.py
+++ b/C#api/Tests/test_orders.py
@@ -133,7 +133,16 @@ class ApiOrdersTests(unittest.TestCase):
         for x in response.json():
             self.assertEqual(x['Order_Status'], "Delivered")
             self.assertEqual(x['Warehouse_Id'], 18)
-            
+      
+    def test_get_order_warehouse(self):
+        order_id = 1
+        response = self.client.get(f"orders/{order_id}/warehouse")
+        self.assertEqual(response.status_code, 200)
+        warehouse = response.json()
+        self.assertIn("Id", warehouse)
+        self.assertIn("Name", warehouse)
+        self.assertIn("Address", warehouse)
+  
     # POST tests
     def test_4create_order(self):
         response = self.client.post("orders", json=self.new_order)

--- a/C#api/Tests/test_orders.py
+++ b/C#api/Tests/test_orders.py
@@ -146,8 +146,7 @@ class ApiOrdersTests(unittest.TestCase):
     def test_get_order_warehouse_invalid_id(self):
         order_id = -1
         response = self.client.get(f"orders/{order_id}/warehouse")
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("Invalid order ID", response.text)
+        self.assertEqual(response.status_code, 204)
   
     # POST tests
     def test_4create_order(self):

--- a/C#api/Tests/test_orders.py
+++ b/C#api/Tests/test_orders.py
@@ -142,6 +142,12 @@ class ApiOrdersTests(unittest.TestCase):
         self.assertIn("Id", warehouse)
         self.assertIn("Name", warehouse)
         self.assertIn("Address", warehouse)
+    
+    def test_get_order_warehouse_invalid_id(self):
+        order_id = -1
+        response = self.client.get(f"orders/{order_id}/warehouse")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid order ID", response.text)
   
     # POST tests
     def test_4create_order(self):

--- a/C#api/Tests/test_shipments.py
+++ b/C#api/Tests/test_shipments.py
@@ -135,6 +135,13 @@ class ApiShipmentsTests(unittest.TestCase):
             self.assertEqual(x['Shipment_Status'], "Pending")
             self.assertEqual(x['Carrier_Code'], "DPD")
 
+    def test_get_shipment_order(self):
+        response = self.client.get("shipments/1/order")
+        self.assertEqual(response.status_code, 200)
+        order = response.json()
+        self.assertIn("Id", order)
+        self.assertEqual(order["Id"], 1)
+
     # POST tests
     def test_4create_shipment(self):
         response = self.client.post("shipments", json=self.new_shipment)

--- a/C#api/Tests/test_shipments.py
+++ b/C#api/Tests/test_shipments.py
@@ -144,8 +144,7 @@ class ApiShipmentsTests(unittest.TestCase):
     
     def test_get_shipment_order_invalid_id(self):
         response = self.client.get("shipments/-1/order")
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("Invalid Shipment ID", response.text)
+        self.assertEqual(response.status_code, 204)
 
     # POST tests
     def test_4create_shipment(self):

--- a/C#api/Tests/test_shipments.py
+++ b/C#api/Tests/test_shipments.py
@@ -141,6 +141,11 @@ class ApiShipmentsTests(unittest.TestCase):
         order = response.json()
         self.assertIn("Id", order)
         self.assertEqual(order["Id"], 1)
+    
+    def test_get_shipment_order_invalid_id(self):
+        response = self.client.get("shipments/-1/order")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid Shipment ID", response.text)
 
     # POST tests
     def test_4create_shipment(self):

--- a/C#api/Tests/test_transfers.py
+++ b/C#api/Tests/test_transfers.py
@@ -116,14 +116,18 @@ class ApiTransfersTests(unittest.TestCase):
             self.assertEqual(x['Transfer_Status'], "Completed")
             self.assertEqual(x['Transfer_To'], 9229)
 
-    def test_get_transfer_locations(self):
+    def test_get_transfer_locations_valid_id(self):
         response = self.client.get("transfers/2/locations")
         self.assertEqual(response.status_code, 200)
         locations = response.json()
-        self.assertIn("SenderLocation", locations)
-        self.assertIn("ReceiverLocation", locations)
-        self.assertEqual(locations["SenderLocation"], 9229)
-        self.assertEqual(locations["ReceiverLocation"], 9284)
+        self.assertIsNotNone(locations)
+        self.assertIn('LocationFrom', locations)
+        self.assertIn('LocationTo', locations)
+
+    def test_get_transfer_locations_invalid_id(self):
+        response = self.client.get("transfers/-1/locations")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid Transfer ID", response.text)
 
     # POST tests
     def test_4create_transfer(self):

--- a/C#api/Tests/test_transfers.py
+++ b/C#api/Tests/test_transfers.py
@@ -126,8 +126,7 @@ class ApiTransfersTests(unittest.TestCase):
 
     def test_get_transfer_locations_invalid_id(self):
         response = self.client.get("transfers/-1/locations")
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("Invalid Transfer ID", response.text)
+        self.assertEqual(response.status_code, 204)
 
     # POST tests
     def test_4create_transfer(self):

--- a/C#api/Tests/test_transfers.py
+++ b/C#api/Tests/test_transfers.py
@@ -116,6 +116,15 @@ class ApiTransfersTests(unittest.TestCase):
             self.assertEqual(x['Transfer_Status'], "Completed")
             self.assertEqual(x['Transfer_To'], 9229)
 
+    def test_get_transfer_locations(self):
+        response = self.client.get("transfers/2/locations")
+        self.assertEqual(response.status_code, 200)
+        locations = response.json()
+        self.assertIn("SenderLocation", locations)
+        self.assertIn("ReceiverLocation", locations)
+        self.assertEqual(locations["SenderLocation"], 9229)
+        self.assertEqual(locations["ReceiverLocation"], 9284)
+
     # POST tests
     def test_4create_transfer(self):
         response = self.client.post("transfers", json=self.new_transfer)


### PR DESCRIPTION
In deze pull request werd aantal userstories die zijn met zelfde functionaliteit gemaakt. Request wordt gedaan door. http://localhost:3000/api/v1/[model name]/[id]/[retrieve detail]
Volgende userstories verwerkt:  

As a System, It should contain an endpoint to view an transfer's sender and receiver when receiving a valid transfer ID (only retrieve Locations in detail).

As a System, It should contain an endpoint to view an shipment's order when receiving a valid shipment ID (only retrieve order in detail).

As a System, It should contain an endpoint to view an location's warehouse when receiving a valid location ID (only retrieve warehouse in detail).

As a System, It should contain an endpoint to view an order's warehouse when receiving a valid order ID (only retrieve order in detail).

As a System, It should contain an endpoint to view an item's supplier when receiving a valid item ID (only retrieve supplier in detail).

As a System, It should contain an endpoint to view an item's itemline, itemgroup or itemtype when receiving a valid item ID (only retrieve itemline, itemgroup or itemtype in detail).
